### PR TITLE
set bindingUpdated correctly if a new binding was created

### DIFF
--- a/src/SslCertBinding.Net/CertificateBindingConfiguration.cs
+++ b/src/SslCertBinding.Net/CertificateBindingConfiguration.cs
@@ -63,6 +63,7 @@ namespace SslCertBinding.Net
 
 						if (HttpApi.ERROR_ALREADY_EXISTS != retVal) {
 							HttpApi.ThrowWin32ExceptionIfError(retVal);
+                            bindingUpdated = true;
 						} else {
 							retVal = HttpApi.HttpDeleteServiceConfiguration(IntPtr.Zero,
 								HttpApi.HTTP_SERVICE_CONFIG_ID.HttpServiceConfigSSLCertInfo,


### PR DESCRIPTION
fixes #6 

bindingUpdated was only set to if an existing binding was deleted and recreated