### PR TITLE
Redesign sni api

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ The current implementation supports these binding families:
 | `scopedccs=www.contoso.com:443` | `ScopedCcsKey` | `ScopedCcsBinding` |
 
 ```c#
+#nullable enable
+
 var config = new SslBindingConfiguration();
-var certificate = new SslCertificateReference(
-    "372680E4AEC4A57CAE698307347C65D3CE38AF60",
-    StoreName.My);
+var certificate = new SslCertificateReference("372680E4AEC4A57CAE698307347C65D3CE38AF60");
 var appId = Guid.Parse("214124cd-d05b-4309-9af9-9caa44b2b74a");
 
 config.Upsert(new IpPortBinding(
@@ -58,13 +58,18 @@ config.Upsert(new ScopedCcsBinding(
     appId));
 
 IReadOnlyList<ISslBinding> allBindings = config.Query();
-HostnamePortBinding sniBinding = config.Find(new HostnamePortKey("www.contoso.com", 443));
-IpPortBinding ipBinding = config.Find(new IpPortKey(IPAddress.Parse("0.0.0.0"), 443));
-CcsPortBinding ccsBinding = config.Find(new CcsPortKey(443));
-ScopedCcsBinding scopedCcsBinding = config.Find(new ScopedCcsKey("www.contoso.com", 443));
-HostnamePortBinding sniBindingFromEndPoint = config.Find(new DnsEndPoint("www.contoso.com", 443).ToHostnamePortKey());
-ScopedCcsBinding scopedCcsBindingFromEndPoint = config.Find(new DnsEndPoint("www.contoso.com", 443).ToScopedCcsKey());
-IpPortBinding ipBindingFromEndPoint = config.Find(new IPEndPoint(IPAddress.Parse("0.0.0.0"), 443).ToSslBindingKey());
+HostnamePortBinding? sniBinding = config.Find(new HostnamePortKey("www.contoso.com", 443));
+IpPortBinding? ipBinding = config.Find(new IpPortKey(IPAddress.Parse("0.0.0.0"), 443));
+CcsPortBinding? ccsBinding = config.Find(new CcsPortKey(443));
+ScopedCcsBinding? scopedCcsBinding = config.Find(new ScopedCcsKey("www.contoso.com", 443));
+HostnamePortBinding? sniBindingFromEndPoint = config.Find(new DnsEndPoint("www.contoso.com", 443).ToHostnamePortKey()!);
+ScopedCcsBinding? scopedCcsBindingFromEndPoint = config.Find(new DnsEndPoint("www.contoso.com", 443).ToScopedCcsKey()!);
+IpPortBinding? ipBindingFromEndPoint = config.Find(new IPEndPoint(IPAddress.Parse("0.0.0.0"), 443).ToSslBindingKey()!);
+
+if (sniBinding is not null)
+{
+    Console.WriteLine(sniBinding.Certificate.Thumbprint);
+}
 
 config.Delete(new HostnamePortKey("www.contoso.com", 443));
 config.Delete(new IpPortKey(IPAddress.Parse("0.0.0.0"), 443));
@@ -85,6 +90,8 @@ IReadOnlyList<ScopedCcsBinding> scopedCcsBindings = config.Query<ScopedCcsBindin
 ```
 
 Exact lookup uses `Find(...)`. It returns the matching binding or `null` when no binding exists for the specified key.
+
+`SslCertificateReference` does not accept a `null` store name. Use `new SslCertificateReference(thumbprint)` when you want the default `MY` store, or pass an explicit non-null store name when you want a different store.
 
 `IpPortKey`, `HostnamePortKey`, and `ScopedCcsKey` define implicit conversions to and from the matching `IPEndPoint` or `DnsEndPoint` shapes where that mapping is natural. `IPEndPoint.ToSslBindingKey()` remains available for the IP family, while `DnsEndPoint` now uses explicit `ToHostnamePortKey()` and `ToScopedCcsKey()` conversions so the hostname-based families stay unambiguous.
 

--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ config.Upsert(new ScopedCcsBinding(
     appId));
 
 IReadOnlyList<ISslBinding> allBindings = config.Query();
-HostnamePortBinding sniBinding = config.Query(new HostnamePortKey("www.contoso.com", 443))[0];
-IpPortBinding ipBinding = config.Query(new IpPortKey(IPAddress.Parse("0.0.0.0"), 443))[0];
-CcsPortBinding ccsBinding = config.Query(new CcsPortKey(443))[0];
-ScopedCcsBinding scopedCcsBinding = config.Query(new ScopedCcsKey("www.contoso.com", 443))[0];
-HostnamePortBinding sniBindingFromEndPoint = config.Query(new DnsEndPoint("www.contoso.com", 443).ToHostnamePortKey())[0];
-ScopedCcsBinding scopedCcsBindingFromEndPoint = config.Query(new DnsEndPoint("www.contoso.com", 443).ToScopedCcsKey())[0];
-IpPortBinding ipBindingFromEndPoint = config.Query(new IPEndPoint(IPAddress.Parse("0.0.0.0"), 443).ToSslBindingKey())[0];
+HostnamePortBinding sniBinding = config.Find(new HostnamePortKey("www.contoso.com", 443));
+IpPortBinding ipBinding = config.Find(new IpPortKey(IPAddress.Parse("0.0.0.0"), 443));
+CcsPortBinding ccsBinding = config.Find(new CcsPortKey(443));
+ScopedCcsBinding scopedCcsBinding = config.Find(new ScopedCcsKey("www.contoso.com", 443));
+HostnamePortBinding sniBindingFromEndPoint = config.Find(new DnsEndPoint("www.contoso.com", 443).ToHostnamePortKey());
+ScopedCcsBinding scopedCcsBindingFromEndPoint = config.Find(new DnsEndPoint("www.contoso.com", 443).ToScopedCcsKey());
+IpPortBinding ipBindingFromEndPoint = config.Find(new IPEndPoint(IPAddress.Parse("0.0.0.0"), 443).ToSslBindingKey());
 
 config.Delete(new HostnamePortKey("www.contoso.com", 443));
 config.Delete(new IpPortKey(IPAddress.Parse("0.0.0.0"), 443));
@@ -83,6 +83,8 @@ IReadOnlyList<HostnamePortBinding> hostnameBindings = config.Query<HostnamePortB
 IReadOnlyList<CcsPortBinding> ccsBindings = config.Query<CcsPortBinding>();
 IReadOnlyList<ScopedCcsBinding> scopedCcsBindings = config.Query<ScopedCcsBinding>();
 ```
+
+Exact lookup uses `Find(...)`. It returns the matching binding or `null` when no binding exists for the specified key.
 
 `IpPortKey`, `HostnamePortKey`, and `ScopedCcsKey` define implicit conversions to and from the matching `IPEndPoint` or `DnsEndPoint` shapes where that mapping is natural. `IPEndPoint.ToSslBindingKey()` remains available for the IP family, while `DnsEndPoint` now uses explicit `ToHostnamePortKey()` and `ToScopedCcsKey()` conversions so the hostname-based families stay unambiguous.
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ CcsPortBinding? ccsBinding = config.Find(new CcsPortKey(443));
 ScopedCcsBinding? scopedCcsBinding = config.Find(new ScopedCcsKey("www.contoso.com", 443));
 HostnamePortBinding? sniBindingFromEndPoint = config.Find(new DnsEndPoint("www.contoso.com", 443).ToHostnamePortKey()!);
 ScopedCcsBinding? scopedCcsBindingFromEndPoint = config.Find(new DnsEndPoint("www.contoso.com", 443).ToScopedCcsKey()!);
-IpPortBinding? ipBindingFromEndPoint = config.Find(new IPEndPoint(IPAddress.Parse("0.0.0.0"), 443).ToSslBindingKey()!);
+IpPortBinding? ipBindingFromEndPoint = config.Find(new IPEndPoint(IPAddress.Parse("0.0.0.0"), 443).ToIpPortKey()!);
 
 if (sniBinding is not null)
 {
@@ -77,7 +77,7 @@ config.Delete(new CcsPortKey(443));
 config.Delete(new ScopedCcsKey("www.contoso.com", 443));
 config.Delete(new DnsEndPoint("www.contoso.com", 443).ToHostnamePortKey());
 config.Delete(new DnsEndPoint("www.contoso.com", 443).ToScopedCcsKey());
-config.Delete(new IPEndPoint(IPAddress.Parse("0.0.0.0"), 443).ToSslBindingKey());
+config.Delete(new IPEndPoint(IPAddress.Parse("0.0.0.0"), 443).ToIpPortKey()!);
 ```
 
 If you want family-specific enumeration, you can use:
@@ -93,7 +93,7 @@ Exact lookup uses `Find(...)`. It returns the matching binding or `null` when no
 
 `SslCertificateReference` does not accept a `null` store name. Use `new SslCertificateReference(thumbprint)` when you want the default `MY` store, or pass an explicit non-null store name when you want a different store.
 
-`IpPortKey`, `HostnamePortKey`, and `ScopedCcsKey` define implicit conversions to and from the matching `IPEndPoint` or `DnsEndPoint` shapes where that mapping is natural. `IPEndPoint.ToSslBindingKey()` remains available for the IP family, while `DnsEndPoint` now uses explicit `ToHostnamePortKey()` and `ToScopedCcsKey()` conversions so the hostname-based families stay unambiguous.
+`IpPortKey`, `HostnamePortKey`, and `ScopedCcsKey` define implicit conversions to and from the matching `IPEndPoint` or `DnsEndPoint` shapes where that mapping is natural. `IPEndPoint.ToIpPortKey()` is the IP-family helper, while `DnsEndPoint` uses explicit `ToHostnamePortKey()` and `ToScopedCcsKey()` conversions so the hostname-based families stay unambiguous.
 
 Only `IpPortBinding` and `HostnamePortBinding` expose `SslCertificateReference`. `CcsPortBinding` and `ScopedCcsBinding` rely on HTTP.sys central certificate store resolution and therefore do not carry certificate thumbprint/store state in the public model.
 

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -8,8 +8,6 @@ It focuses on the API surface that exists today:
 2. the CCS and scoped CCS families exposed by the same model
 3. the active non-obsolete configuration and binding types used by that model
 
-`SslBindingConfiguration` also exposes concrete exact-query overloads for `CcsPortKey` and `ScopedCcsKey`. They are intentionally not part of `ISslBindingConfiguration`, which stays source/binary-compatible for downstream custom implementations.
-
 `SslBindingKeyExtensions` is intentionally omitted from the diagram because it provides endpoint conversion helpers but does not change the core object model.
 
 ## Class Diagram
@@ -90,17 +88,14 @@ classDiagram
         <<interface>>
         +Query() IReadOnlyList~ISslBinding~
         +Query~TBinding~() IReadOnlyList~TBinding~
-        +Query(IpPortKey key) IReadOnlyList~IpPortBinding~
-        +Query(HostnamePortKey key) IReadOnlyList~HostnamePortBinding~
-        +Query(SslBindingKey key) IReadOnlyList~ISslBinding~
+        +Find(IpPortKey key) IpPortBinding
+        +Find(HostnamePortKey key) HostnamePortBinding
+        +Find(CcsPortKey key) CcsPortBinding
+        +Find(ScopedCcsKey key) ScopedCcsBinding
+        +Find(SslBindingKey key) ISslBinding
         +Upsert(ISslBinding binding)
         +Delete(SslBindingKey key)
         +Delete(IReadOnlyCollection~SslBindingKey~ keys)
-    }
-
-    class SslBindingConfiguration {
-        +Query(CcsPortKey key) IReadOnlyList~CcsPortBinding~
-        +Query(ScopedCcsKey key) IReadOnlyList~ScopedCcsBinding~
     }
 
     SslBindingKey --> SslBindingKind
@@ -125,12 +120,14 @@ classDiagram
     IpPortBinding --> SslCertificateReference
     HostnamePortBinding --> SslCertificateReference
 
-    ISslBindingConfiguration <|.. SslBindingConfiguration
     ISslBindingConfiguration ..> ISslBinding
     ISslBindingConfiguration ..> SslBindingKey
     ISslBindingConfiguration ..> IpPortBinding
     ISslBindingConfiguration ..> HostnamePortBinding
+    ISslBindingConfiguration <|.. SslBindingConfiguration
 ```
+
+Exact lookup now uses `Find(...)` and returns the matching binding or `null` when no binding exists for the specified key.
 
 ## Endpoint Conversions
 

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -88,11 +88,11 @@ classDiagram
         <<interface>>
         +Query() IReadOnlyList~ISslBinding~
         +Query~TBinding~() IReadOnlyList~TBinding~
-        +Find(IpPortKey key) IpPortBinding
-        +Find(HostnamePortKey key) HostnamePortBinding
-        +Find(CcsPortKey key) CcsPortBinding
-        +Find(ScopedCcsKey key) ScopedCcsBinding
-        +Find(SslBindingKey key) ISslBinding
+        +Find(IpPortKey key) IpPortBinding?
+        +Find(HostnamePortKey key) HostnamePortBinding?
+        +Find(CcsPortKey key) CcsPortBinding?
+        +Find(ScopedCcsKey key) ScopedCcsBinding?
+        +Find(SslBindingKey key) ISslBinding?
         +Upsert(ISslBinding binding)
         +Delete(SslBindingKey key)
         +Delete(IReadOnlyCollection~SslBindingKey~ keys)
@@ -149,7 +149,7 @@ The extension methods support the endpoint-to-key direction when you want the ca
 
 ```mermaid
 flowchart LR
-    IPEndPoint -->|"ToSslBindingKey()"| IpPortKey
+    IPEndPoint -->|"ToIpPortKey()"| IpPortKey
     DnsEndPoint -->|"ToHostnamePortKey()"| HostnamePortKey
     DnsEndPoint -->|"ToScopedCcsKey()"| ScopedCcsKey
 ```
@@ -179,7 +179,7 @@ DnsEndPoint roundTrippedScopedDnsEndPoint = scopedCcsKey;
 ### Extension Method Examples
 
 ```csharp
-IpPortKey ipKey = new IPEndPoint(IPAddress.Any, 443).ToSslBindingKey();
+IpPortKey ipKey = new IPEndPoint(IPAddress.Any, 443).ToIpPortKey();
 HostnamePortKey hostnameKey = new DnsEndPoint("www.contoso.com", 443).ToHostnamePortKey();
 ScopedCcsKey scopedCcsKey = new DnsEndPoint("www.contoso.com", 443).ToScopedCcsKey();
 ```
@@ -187,8 +187,17 @@ ScopedCcsKey scopedCcsKey = new DnsEndPoint("www.contoso.com", 443).ToScopedCcsK
 ### When To Use Which
 
 1. Use the implicit operators when you want concise type-safe conversion between a concrete endpoint type and its matching concrete key type.
-2. Use `ToSslBindingKey()`, `ToHostnamePortKey()`, or `ToScopedCcsKey()` when you want the code to read explicitly as a binding-key conversion at the call site.
+2. Use `ToIpPortKey()`, `ToHostnamePortKey()`, or `ToScopedCcsKey()` when you want the code to read explicitly as a binding-key conversion at the call site.
 3. Use the concrete key constructors or `From(...)` methods when that style is clearer for your codebase than either operators or extension methods.
+
+## Nullable Notes
+
+The current API is annotated for nullable reference types.
+
+1. `Find(...)` returns the matching binding or `null` when no binding exists for the specified key.
+2. Endpoint conversion helpers return `null` when the source endpoint is `null`.
+3. `BindingOptions.SslCtlIdentifier` and `BindingOptions.SslCtlStoreName` are optional and may be `null`.
+4. `SslCertificateReference` does not accept a `null` store name. Use `new SslCertificateReference(thumbprint)` when you want the default `MY` store.
 
 ## Scope Notes
 

--- a/docs/ssl-binding-family-design.md
+++ b/docs/ssl-binding-family-design.md
@@ -6,32 +6,33 @@
 
 ## Implementation Status
 
-The current implementation in this repository intentionally stops after the SNI milestone from the recommended sequence:
-
-1. introduce the new binding-family model
-2. re-implement IP on top of it
-3. add SNI
+The current implementation in this repository now ships the full binding-family surface described by this design.
 
 Implemented now:
 
-- new generalized `SslBindingConfiguration` supports `ipport` and `hostnameport`
+- new generalized `SslBindingConfiguration` supports `ipport`, `hostnameport`, `ccs`, and `scopedccs`
 - the new public domain model currently includes:
   - `SslBindingKind`
   - `SslBindingKey`
   - `IpPortKey`
   - `HostnamePortKey`
+  - `CcsPortKey`
+  - `ScopedCcsKey`
   - `SslCertificateReference`
   - `ISslBinding`
+  - `SslBinding<TKey>`
   - `IpPortBinding`
   - `HostnamePortBinding`
-
-Not implemented yet:
-
-- `CcsPortKey`
-- `ScopedCcsKey`
-- `CcsPortBinding`
-- `ScopedCcsBinding`
+  - `CcsPortBinding`
+  - `ScopedCcsBinding`
 - CCS and scoped CCS HTTP API handlers
+- nullable-reference annotations across the public surface
+
+Still true from the earlier design draft:
+
+- the binding-family model was the right abstraction
+- `BindingEndPoint` / `AnyHostPort` would not have scaled cleanly to CCS
+- the old IP-only surface remains only as obsolete compatibility wrappers
 
 One small implementation detail differs from the earlier draft below: the shipped model now uses a hybrid interface/class model:
 
@@ -59,7 +60,7 @@ But I would not continue extending the current public `BindingEndPoint` model to
 
 The cleaner design is to model **binding family** explicitly and make endpoint-like values just one kind of binding key.
 
-This document describes the target design if the feature is implemented fresh over `master`. `support-sni` is treated here as a useful implementation reference, not as the public API baseline.
+This document now serves mainly as design rationale for the shipped API. Some sections below still describe the rollout as stages because they explain how the current model was derived.
 
 ## Deep Reviewer Takeaway
 
@@ -111,7 +112,7 @@ That makes the public API look simpler, but the underlying native semantics beco
 
 ### 3. The current public API was generalized too early
 
-Compared to `master`, the target implementation replaces the narrow IP-only API with a generalized binding-family API. That is acceptable here because the next-major-version direction is to make the new model the primary public surface rather than preserving the old one indefinitely.
+Compared to the original `master` IP-only API, the implementation replaces the narrow surface with a generalized binding-family API. In the current codebase, the old IP-only surface remains available only as obsolete compatibility wrappers while the binding-family model is the primary public surface for new code.
 
 ## Recommended Design Direction
 
@@ -237,11 +238,11 @@ For the current shipped public API, including the standalone Mermaid diagram, se
 
 ### Target Domain Model
 
-The Mermaid diagram below is a target-state model, not a strict snapshot of the currently shipped types.
+The Mermaid diagram below is effectively the current shipped model.
 
-1. The current code ships the `IpPortKey` and `HostnamePortKey` families, the `SslBinding` / `SslBinding<TKey>` base types, `IpPortBinding`, `HostnamePortBinding`, and `SslCertificateReference`.
+1. The current code ships `IpPortKey`, `HostnamePortKey`, `CcsPortKey`, and `ScopedCcsKey`, along with `ISslBinding`, `SslBinding<TKey>`, all four concrete binding types, and `SslCertificateReference`.
 2. The current code also keeps `CertificateBinding`, `ICertificateBindingConfiguration`, and `CertificateBindingConfiguration` as obsolete IP-only compatibility wrappers.
-3. `ScopedCcsKey`, `CcsPortKey`, `ScopedCcsBinding`, and `CcsPortBinding` remain planned rather than implemented.
+3. `SslCertificateReference` now uses a strict non-null store-name contract for explicit store names; callers use the one-argument overload when they want the default `MY` store.
 
 ```mermaid
 classDiagram
@@ -342,20 +343,22 @@ classDiagram
 ```csharp
 public interface ISslBindingConfiguration
 {
-    IReadOnlyList<SslBinding> Query();
-    IReadOnlyList<TBinding> Query<TBinding>() where TBinding : SslBinding;
-    IpPortBinding Find(IpPortKey key);
-    HostnamePortBinding Find(HostnamePortKey key);
-    CcsPortBinding Find(CcsPortKey key);
-    ScopedCcsBinding Find(ScopedCcsKey key);
-    SslBinding Find(SslBindingKey key);
-    void Upsert(SslBinding binding);
+    IReadOnlyList<ISslBinding> Query();
+    IReadOnlyList<TBinding> Query<TBinding>() where TBinding : ISslBinding;
+    IpPortBinding? Find(IpPortKey key);
+    HostnamePortBinding? Find(HostnamePortKey key);
+    CcsPortBinding? Find(CcsPortKey key);
+    ScopedCcsBinding? Find(ScopedCcsKey key);
+    ISslBinding? Find(SslBindingKey key);
+    void Upsert(ISslBinding binding);
     void Delete(SslBindingKey key);
     void Delete(IReadOnlyCollection<SslBindingKey> keys);
 }
 ```
 
 Typed `Find(...)` overloads let callers avoid casts for exact lookup, while `Query<TBinding>()` provides family-specific enumeration without adding one method per binding family.
+
+In the shipped API, `Find(...)` follows a "get or null" contract rather than a `TryFind(...)` pattern.
 
 ## Implementation Strategy Over `master`
 

--- a/docs/ssl-binding-family-design.md
+++ b/docs/ssl-binding-family-design.md
@@ -135,7 +135,7 @@ I recommend a new generalized API over `master`, with the generalized model beco
 
 #### 1. `SslBindingKey`
 
-Represents how a binding is identified for exact query and delete.
+Represents how a binding is identified for exact lookup and delete.
 
 Proposed subtypes:
 
@@ -344,15 +344,18 @@ public interface ISslBindingConfiguration
 {
     IReadOnlyList<SslBinding> Query();
     IReadOnlyList<TBinding> Query<TBinding>() where TBinding : SslBinding;
-    IReadOnlyList<IpPortBinding> Query(IpPortKey key);
-    IReadOnlyList<HostnamePortBinding> Query(HostnamePortKey key);
+    IpPortBinding Find(IpPortKey key);
+    HostnamePortBinding Find(HostnamePortKey key);
+    CcsPortBinding Find(CcsPortKey key);
+    ScopedCcsBinding Find(ScopedCcsKey key);
+    SslBinding Find(SslBindingKey key);
     void Upsert(SslBinding binding);
     void Delete(SslBindingKey key);
     void Delete(IReadOnlyCollection<SslBindingKey> keys);
 }
 ```
 
-Typed query overloads let callers avoid casts for exact queries, while `Query<TBinding>()` provides family-specific enumeration without adding one method per binding family.
+Typed `Find(...)` overloads let callers avoid casts for exact lookup, while `Query<TBinding>()` provides family-specific enumeration without adding one method per binding family.
 
 ## Implementation Strategy Over `master`
 
@@ -464,7 +467,7 @@ Work:
 - implement `CcsPortBinding`
 - implement `CcsPortBindingHandler`
 - add `netsh` helper support for `ccs`
-- add exact query, enumeration, bind, and delete tests for `ccs=443`
+- add exact lookup, enumeration, bind, and delete tests for `ccs=443`
 
 Deliverable:
 
@@ -484,7 +487,7 @@ Work:
 - implement `ScopedCcsBinding`
 - implement `ScopedCcsBindingHandler`
 - add `netsh` helper support for `scopedccs`
-- add exact query, enumeration, bind, and delete tests for `scopedccs=www.contoso.com:443`
+- add exact lookup, enumeration, bind, and delete tests for `scopedccs=www.contoso.com:443`
 
 Deliverable:
 
@@ -821,7 +824,7 @@ The test harness should grow family-by-family rather than assuming only `ipport`
 
 Recommended additions:
 
-- exact query/add/delete tests for each binding family
+- exact lookup/add/delete tests for each binding family
 - `netsh` helper support for `ccs` and `scopedccs`
 - round-trip tests for each native family
 

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -6,6 +6,7 @@
     <EnforceCodeStyleInBuild>True</EnforceCodeStyleInBuild>
     <AnalysisLevel>latest-recommended</AnalysisLevel>
     <LangVersion>12.0</LangVersion>
+    <Nullable>enable</Nullable>
     <EnablePackageValidation>true</EnablePackageValidation>
   </PropertyGroup>
   

--- a/src/SslCertBinding.Net.Sample/Program.cs
+++ b/src/SslCertBinding.Net.Sample/Program.cs
@@ -47,7 +47,7 @@ namespace SslCertBinding.Net.Sample
             IEnumerable<ISslBinding> bindings = args.Length switch
             {
                 1 => configuration.Query(),
-                3 => QueryOne(configuration, ParseBindingKey(ParseBindingKind(args[1]), args[2])),
+                3 => FindOne(configuration, ParseBindingKey(ParseBindingKind(args[1]), args[2])),
                 _ => throw new ArgumentException("Use 'show' or 'show <family> <bindingKey>'.", nameof(args)),
             };
 
@@ -162,21 +162,28 @@ namespace SslCertBinding.Net.Sample
             Console.WriteLine("The binding record has been successfully removed.");
         }
 
-        private static IEnumerable<ISslBinding> QueryOne(SslBindingConfiguration configuration, SslBindingKey key)
+        private static IEnumerable<ISslBinding> FindOne(SslBindingConfiguration configuration, SslBindingKey key)
         {
+            ISslBinding binding;
             switch (key)
             {
                 case IpPortKey ipKey:
-                    return configuration.Query(ipKey);
+                    binding = configuration.Find(ipKey);
+                    break;
                 case HostnamePortKey hostnameKey:
-                    return configuration.Query(hostnameKey);
+                    binding = configuration.Find(hostnameKey);
+                    break;
                 case CcsPortKey ccsKey:
-                    return configuration.Query(ccsKey);
+                    binding = configuration.Find(ccsKey);
+                    break;
                 case ScopedCcsKey scopedCcsKey:
-                    return configuration.Query(scopedCcsKey);
+                    binding = configuration.Find(scopedCcsKey);
+                    break;
                 default:
                     return Enumerable.Empty<ISslBinding>();
             }
+
+            return binding == null ? Enumerable.Empty<ISslBinding>() : new[] { binding };
         }
 
         private static SslBindingKind ParseBindingKind(string value)

--- a/src/SslCertBinding.Net.Sample/SslCertBinding.Net.Sample.csproj
+++ b/src/SslCertBinding.Net.Sample/SslCertBinding.Net.Sample.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>net462;net8.0-windows;net8.0</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyInfo>True</GenerateAssemblyInfo>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\SslCertBinding.Net\SslCertBinding.Net.csproj" />

--- a/src/SslCertBinding.Net.Tests/Compatibility/CertificateBindingCompatibilityTests.cs
+++ b/src/SslCertBinding.Net.Tests/Compatibility/CertificateBindingCompatibilityTests.cs
@@ -7,6 +7,7 @@ using System.Net;
 using System.Security.Cryptography.X509Certificates;
 using NUnit.Framework;
 
+#nullable disable
 namespace SslCertBinding.Net.Tests
 {
     [TestFixture]

--- a/src/SslCertBinding.Net.Tests/Compatibility/CertificateBindingCompatibilityTests.cs
+++ b/src/SslCertBinding.Net.Tests/Compatibility/CertificateBindingCompatibilityTests.cs
@@ -114,7 +114,7 @@ namespace SslCertBinding.Net.Tests
         }
 
         [Test]
-        public void QueryByIpEndPointUsesTypedQuery()
+        public void FindByIpEndPointUsesTypedFind()
         {
             var endPoint = new IPEndPoint(IPAddress.Loopback, 443);
             var binding = new IpPortBinding(
@@ -124,7 +124,7 @@ namespace SslCertBinding.Net.Tests
                 new BindingOptions { NegotiateCertificate = true });
             var stub = new StubConfiguration
             {
-                QueryByIpKeyResult = new[] { binding },
+                FindByIpKeyResult = binding,
             };
             var configuration = new CertificateBindingConfiguration(stub);
 
@@ -132,10 +132,26 @@ namespace SslCertBinding.Net.Tests
 
             Assert.Multiple(() =>
             {
-                Assert.That(stub.QueryByIpKeyArgument, Is.EqualTo(binding.Key));
+                Assert.That(stub.FindByIpKeyArgument, Is.EqualTo(binding.Key));
                 Assert.That(result, Has.Count.EqualTo(1));
                 Assert.That(result[0].IpPort, Is.EqualTo(endPoint));
                 Assert.That(result[0].Options.NegotiateCertificate, Is.True);
+            });
+        }
+
+        [Test]
+        public void FindByIpEndPointReturnsEmptyWhenFindMisses()
+        {
+            var endPoint = new IPEndPoint(IPAddress.Loopback, 443);
+            var stub = new StubConfiguration();
+            var configuration = new CertificateBindingConfiguration(stub);
+
+            IReadOnlyList<CertificateBinding> result = configuration.Query(endPoint);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(stub.FindByIpKeyArgument, Is.EqualTo(new IpPortKey(endPoint)));
+                Assert.That(result, Is.Empty);
             });
         }
 
@@ -301,10 +317,10 @@ namespace SslCertBinding.Net.Tests
         {
             public IReadOnlyList<ISslBinding> QueryAllBindingsResult { get; set; } = Array.Empty<ISslBinding>();
             public IReadOnlyList<IpPortBinding> QueryAllIpBindingsResult { get; set; } = Array.Empty<IpPortBinding>();
-            public IReadOnlyList<IpPortBinding> QueryByIpKeyResult { get; set; } = Array.Empty<IpPortBinding>();
+            public IpPortBinding FindByIpKeyResult { get; set; }
             public ISslBinding UpsertArgument { get; private set; }
             public IReadOnlyCollection<SslBindingKey> DeleteArguments { get; private set; }
-            public IpPortKey QueryByIpKeyArgument { get; private set; }
+            public IpPortKey FindByIpKeyArgument { get; private set; }
             public bool QueryAllCalled { get; private set; }
 
             public IReadOnlyList<ISslBinding> Query()
@@ -323,28 +339,28 @@ namespace SslCertBinding.Net.Tests
                 throw new NotSupportedException();
             }
 
-            public IReadOnlyList<IpPortBinding> Query(IpPortKey key)
+            public IpPortBinding Find(IpPortKey key)
             {
-                QueryByIpKeyArgument = key;
-                return QueryByIpKeyResult;
+                FindByIpKeyArgument = key;
+                return FindByIpKeyResult;
             }
 
-            public IReadOnlyList<HostnamePortBinding> Query(HostnamePortKey key)
-            {
-                throw new NotSupportedException();
-            }
-
-            public IReadOnlyList<CcsPortBinding> Query(CcsPortKey key)
+            public HostnamePortBinding Find(HostnamePortKey key)
             {
                 throw new NotSupportedException();
             }
 
-            public IReadOnlyList<ScopedCcsBinding> Query(ScopedCcsKey key)
+            public CcsPortBinding Find(CcsPortKey key)
             {
                 throw new NotSupportedException();
             }
 
-            public IReadOnlyList<ISslBinding> Query(SslBindingKey key)
+            public ScopedCcsBinding Find(ScopedCcsKey key)
+            {
+                throw new NotSupportedException();
+            }
+
+            public ISslBinding Find(SslBindingKey key)
             {
                 throw new NotSupportedException();
             }

--- a/src/SslCertBinding.Net.Tests/Compatibility/CertificateBindingConfigurationLinuxTests.cs
+++ b/src/SslCertBinding.Net.Tests/Compatibility/CertificateBindingConfigurationLinuxTests.cs
@@ -11,7 +11,7 @@ namespace SslCertBinding.Net.Tests
     public class SslBindingConfigurationLinuxTests
     {
         [Test]
-        public void QueryOnLinuxIsNotSupported()
+        public void QueryAllOnLinuxIsNotSupported()
         {
             var config = new SslBindingConfiguration();
             PlatformNotSupportedException ex = Assert.Throws<PlatformNotSupportedException>(() => _ = config.Query());
@@ -19,34 +19,34 @@ namespace SslCertBinding.Net.Tests
         }
 
         [Test]
-        public void QueryExactOnLinuxIsNotSupported()
+        public void FindByIpKeyOnLinuxIsNotSupported()
         {
             var config = new SslBindingConfiguration();
-            PlatformNotSupportedException ex = Assert.Throws<PlatformNotSupportedException>(() => _ = config.Query(new IpPortKey(IPAddress.Any, 443)));
+            PlatformNotSupportedException ex = Assert.Throws<PlatformNotSupportedException>(() => _ = config.Find(new IpPortKey(IPAddress.Any, 443)));
             Assert.That(ex.InnerException, Is.Null);
         }
 
         [Test]
-        public void QueryByIpEndPointOnLinuxIsNotSupported()
+        public void FindByIpEndPointOnLinuxIsNotSupported()
         {
             var config = new SslBindingConfiguration();
-            PlatformNotSupportedException ex = Assert.Throws<PlatformNotSupportedException>(() => _ = config.Query(new IPEndPoint(IPAddress.Any, 443).ToSslBindingKey()));
+            PlatformNotSupportedException ex = Assert.Throws<PlatformNotSupportedException>(() => _ = config.Find(new IPEndPoint(IPAddress.Any, 443).ToSslBindingKey()));
             Assert.That(ex.InnerException, Is.Null);
         }
 
         [Test]
-        public void QueryByDnsEndPointOnLinuxIsNotSupported()
+        public void FindByDnsEndPointOnLinuxIsNotSupported()
         {
             var config = new SslBindingConfiguration();
-            PlatformNotSupportedException ex = Assert.Throws<PlatformNotSupportedException>(() => _ = config.Query(new DnsEndPoint("localhost", 443).ToHostnamePortKey()));
+            PlatformNotSupportedException ex = Assert.Throws<PlatformNotSupportedException>(() => _ = config.Find(new DnsEndPoint("localhost", 443).ToHostnamePortKey()));
             Assert.That(ex.InnerException, Is.Null);
         }
 
         [Test]
-        public void QueryByScopedCcsDnsEndPointOnLinuxIsNotSupported()
+        public void FindByScopedCcsDnsEndPointOnLinuxIsNotSupported()
         {
             var config = new SslBindingConfiguration();
-            PlatformNotSupportedException ex = Assert.Throws<PlatformNotSupportedException>(() => _ = config.Query(new DnsEndPoint("localhost", 443).ToScopedCcsKey()));
+            PlatformNotSupportedException ex = Assert.Throws<PlatformNotSupportedException>(() => _ = config.Find(new DnsEndPoint("localhost", 443).ToScopedCcsKey()));
             Assert.That(ex.InnerException, Is.Null);
         }
 

--- a/src/SslCertBinding.Net.Tests/Compatibility/CertificateBindingConfigurationLinuxTests.cs
+++ b/src/SslCertBinding.Net.Tests/Compatibility/CertificateBindingConfigurationLinuxTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Net;
 using NUnit.Framework;
 
+#nullable disable
 namespace SslCertBinding.Net.Tests
 {
     [TestFixture]

--- a/src/SslCertBinding.Net.Tests/Compatibility/CertificateBindingConfigurationLinuxTests.cs
+++ b/src/SslCertBinding.Net.Tests/Compatibility/CertificateBindingConfigurationLinuxTests.cs
@@ -31,7 +31,7 @@ namespace SslCertBinding.Net.Tests
         public void FindByIpEndPointOnLinuxIsNotSupported()
         {
             var config = new SslBindingConfiguration();
-            PlatformNotSupportedException ex = Assert.Throws<PlatformNotSupportedException>(() => _ = config.Find(new IPEndPoint(IPAddress.Any, 443).ToSslBindingKey()));
+            PlatformNotSupportedException ex = Assert.Throws<PlatformNotSupportedException>(() => _ = config.Find(new IPEndPoint(IPAddress.Any, 443).ToIpPortKey()));
             Assert.That(ex.InnerException, Is.Null);
         }
 
@@ -63,7 +63,7 @@ namespace SslCertBinding.Net.Tests
         public void DeleteByIpEndPointOnLinuxIsNotSupported()
         {
             var config = new SslBindingConfiguration();
-            PlatformNotSupportedException ex = Assert.Throws<PlatformNotSupportedException>(() => config.Delete(new IPEndPoint(IPAddress.Any, 443).ToSslBindingKey()));
+            PlatformNotSupportedException ex = Assert.Throws<PlatformNotSupportedException>(() => config.Delete(new IPEndPoint(IPAddress.Any, 443).ToIpPortKey()));
             Assert.That(ex.InnerException, Is.Null);
         }
 

--- a/src/SslCertBinding.Net.Tests/Configuration/SslBindingConfigurationContractTests.cs
+++ b/src/SslCertBinding.Net.Tests/Configuration/SslBindingConfigurationContractTests.cs
@@ -16,8 +16,9 @@ namespace SslCertBinding.Net.Tests
         public void FindByIpKeyRejectsNull()
         {
             var configuration = new SslBindingConfiguration();
+            IpPortKey? key = null;
 
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => configuration.Find((IpPortKey)null));
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => configuration.Find(key!));
             Assert.That(ex.ParamName, Is.EqualTo("key"));
         }
 
@@ -25,8 +26,9 @@ namespace SslCertBinding.Net.Tests
         public void FindByHostnameKeyRejectsNull()
         {
             var configuration = new SslBindingConfiguration();
+            HostnamePortKey? key = null;
 
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => configuration.Find((HostnamePortKey)null));
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => configuration.Find(key!));
             Assert.That(ex.ParamName, Is.EqualTo("key"));
         }
 
@@ -34,8 +36,9 @@ namespace SslCertBinding.Net.Tests
         public void FindByUntypedKeyRejectsNull()
         {
             var configuration = new SslBindingConfiguration();
+            SslBindingKey? key = null;
 
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => configuration.Find((SslBindingKey)null));
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => configuration.Find(key!));
             Assert.That(ex.ParamName, Is.EqualTo("key"));
         }
 
@@ -44,7 +47,7 @@ namespace SslCertBinding.Net.Tests
         {
             var configuration = new SslBindingConfiguration();
 
-            ISslBinding result = configuration.Find((SslBindingKey)new IpPortKey(IPAddress.Any, 65535));
+            ISslBinding? result = configuration.Find((SslBindingKey)new IpPortKey(IPAddress.Any, 65535));
 
             Assert.That(result, Is.Null);
         }
@@ -54,7 +57,7 @@ namespace SslCertBinding.Net.Tests
         {
             var configuration = new SslBindingConfiguration();
 
-            ISslBinding result = configuration.Find((SslBindingKey)new HostnamePortKey("localhost", 65535));
+            ISslBinding? result = configuration.Find((SslBindingKey)new HostnamePortKey("localhost", 65535));
 
             Assert.That(result, Is.Null);
         }
@@ -63,8 +66,9 @@ namespace SslCertBinding.Net.Tests
         public void FindByCcsKeyRejectsNull()
         {
             var configuration = new SslBindingConfiguration();
+            CcsPortKey? key = null;
 
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => configuration.Find((CcsPortKey)null));
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => configuration.Find(key!));
             Assert.That(ex.ParamName, Is.EqualTo("key"));
         }
 
@@ -72,8 +76,9 @@ namespace SslCertBinding.Net.Tests
         public void FindByScopedCcsKeyRejectsNull()
         {
             var configuration = new SslBindingConfiguration();
+            ScopedCcsKey? key = null;
 
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => configuration.Find((ScopedCcsKey)null));
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => configuration.Find(key!));
             Assert.That(ex.ParamName, Is.EqualTo("key"));
         }
 
@@ -82,7 +87,7 @@ namespace SslCertBinding.Net.Tests
         {
             var configuration = new SslBindingConfiguration();
 
-            ISslBinding result = configuration.Find((SslBindingKey)new CcsPortKey(65535));
+            ISslBinding? result = configuration.Find((SslBindingKey)new CcsPortKey(65535));
 
             Assert.That(result, Is.Null);
         }
@@ -92,7 +97,7 @@ namespace SslCertBinding.Net.Tests
         {
             var configuration = new SslBindingConfiguration();
 
-            ISslBinding result = configuration.Find((SslBindingKey)new ScopedCcsKey("localhost", 65535));
+            ISslBinding? result = configuration.Find((SslBindingKey)new ScopedCcsKey("localhost", 65535));
 
             Assert.That(result, Is.Null);
         }
@@ -103,7 +108,7 @@ namespace SslCertBinding.Net.Tests
             var configuration = new SslBindingConfiguration();
             var endPoint = new IPEndPoint(IPAddress.Any, 65535);
 
-            IpPortBinding result = configuration.Find(endPoint.ToSslBindingKey());
+            IpPortBinding? result = configuration.Find(endPoint.ToSslBindingKey()!);
 
             Assert.That(result, Is.Null);
         }
@@ -114,7 +119,7 @@ namespace SslCertBinding.Net.Tests
             var configuration = new SslBindingConfiguration();
             var endPoint = new DnsEndPoint("localhost", 65535);
 
-            HostnamePortBinding result = configuration.Find(endPoint.ToHostnamePortKey());
+            HostnamePortBinding? result = configuration.Find(endPoint.ToHostnamePortKey()!);
 
             Assert.That(result, Is.Null);
         }
@@ -125,7 +130,7 @@ namespace SslCertBinding.Net.Tests
             var configuration = new SslBindingConfiguration();
             var endPoint = new DnsEndPoint("localhost", 65535);
 
-            ScopedCcsBinding result = configuration.Find(endPoint.ToScopedCcsKey());
+            ScopedCcsBinding? result = configuration.Find(endPoint.ToScopedCcsKey()!);
 
             Assert.That(result, Is.Null);
         }
@@ -134,8 +139,9 @@ namespace SslCertBinding.Net.Tests
         public void UpsertRejectsNullBinding()
         {
             var configuration = new SslBindingConfiguration();
+            ISslBinding? binding = null;
 
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => configuration.Upsert(null));
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => configuration.Upsert(binding!));
             Assert.That(ex.ParamName, Is.EqualTo("binding"));
         }
 
@@ -143,8 +149,9 @@ namespace SslCertBinding.Net.Tests
         public void DeleteRejectsNullKey()
         {
             var configuration = new SslBindingConfiguration();
+            SslBindingKey? key = null;
 
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => configuration.Delete((SslBindingKey)null));
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => configuration.Delete(key!));
             Assert.That(ex.ParamName, Is.EqualTo("key"));
         }
 
@@ -152,8 +159,9 @@ namespace SslCertBinding.Net.Tests
         public void DeleteRejectsNullKeyCollection()
         {
             var configuration = new SslBindingConfiguration();
+            IReadOnlyCollection<SslBindingKey>? keys = null;
 
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => configuration.Delete((IReadOnlyCollection<SslBindingKey>)null));
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => configuration.Delete(keys!));
             Assert.That(ex.ParamName, Is.EqualTo("keys"));
         }
 
@@ -169,7 +177,7 @@ namespace SslCertBinding.Net.Tests
         public void DeleteRejectsCollectionContainingNullItem()
         {
             var configuration = new SslBindingConfiguration();
-            SslBindingKey[] keys = { new IpPortKey(IPAddress.Any, 65535), null };
+            SslBindingKey[] keys = { new IpPortKey(IPAddress.Any, 65535), null! };
 
             ArgumentException ex = Assert.Throws<ArgumentException>(() => configuration.Delete(keys));
             Assert.That(ex.ParamName, Is.EqualTo("keys"));
@@ -214,7 +222,7 @@ namespace SslCertBinding.Net.Tests
         [Test]
         public void ToSslBindingKeyReturnsNullForNullIpEndPoint()
         {
-            IPEndPoint endPoint = null;
+            IPEndPoint? endPoint = null;
 
             Assert.That(endPoint.ToSslBindingKey(), Is.Null);
         }
@@ -222,7 +230,7 @@ namespace SslCertBinding.Net.Tests
         [Test]
         public void ToHostnamePortKeyReturnsNullForNullDnsEndPoint()
         {
-            DnsEndPoint endPoint = null;
+            DnsEndPoint? endPoint = null;
 
             Assert.That(endPoint.ToHostnamePortKey(), Is.Null);
         }
@@ -230,7 +238,7 @@ namespace SslCertBinding.Net.Tests
         [Test]
         public void ToScopedCcsKeyReturnsNullForNullDnsEndPoint()
         {
-            DnsEndPoint endPoint = null;
+            DnsEndPoint? endPoint = null;
 
             Assert.That(endPoint.ToScopedCcsKey(), Is.Null);
         }

--- a/src/SslCertBinding.Net.Tests/Configuration/SslBindingConfigurationContractTests.cs
+++ b/src/SslCertBinding.Net.Tests/Configuration/SslBindingConfigurationContractTests.cs
@@ -108,7 +108,7 @@ namespace SslCertBinding.Net.Tests
             var configuration = new SslBindingConfiguration();
             var endPoint = new IPEndPoint(IPAddress.Any, 65535);
 
-            IpPortBinding? result = configuration.Find(endPoint.ToSslBindingKey()!);
+            IpPortBinding? result = configuration.Find(endPoint.ToIpPortKey()!);
 
             Assert.That(result, Is.Null);
         }
@@ -220,11 +220,11 @@ namespace SslCertBinding.Net.Tests
         }
 
         [Test]
-        public void ToSslBindingKeyReturnsNullForNullIpEndPoint()
+        public void ToIpPortKeyReturnsNullForNullIpEndPoint()
         {
             IPEndPoint? endPoint = null;
 
-            Assert.That(endPoint.ToSslBindingKey(), Is.Null);
+            Assert.That(endPoint.ToIpPortKey(), Is.Null);
         }
 
         [Test]

--- a/src/SslCertBinding.Net.Tests/Configuration/SslBindingConfigurationContractTests.cs
+++ b/src/SslCertBinding.Net.Tests/Configuration/SslBindingConfigurationContractTests.cs
@@ -13,121 +13,121 @@ namespace SslCertBinding.Net.Tests
     public class SslBindingConfigurationContractTests
     {
         [Test]
-        public void QueryByIpKeyRejectsNull()
+        public void FindByIpKeyRejectsNull()
         {
             var configuration = new SslBindingConfiguration();
 
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => configuration.Query((IpPortKey)null));
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => configuration.Find((IpPortKey)null));
             Assert.That(ex.ParamName, Is.EqualTo("key"));
         }
 
         [Test]
-        public void QueryByHostnameKeyRejectsNull()
+        public void FindByHostnameKeyRejectsNull()
         {
             var configuration = new SslBindingConfiguration();
 
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => configuration.Query((HostnamePortKey)null));
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => configuration.Find((HostnamePortKey)null));
             Assert.That(ex.ParamName, Is.EqualTo("key"));
         }
 
         [Test]
-        public void QueryByUntypedKeyRejectsNull()
+        public void FindByUntypedKeyRejectsNull()
         {
             var configuration = new SslBindingConfiguration();
 
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => configuration.Query((SslBindingKey)null));
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => configuration.Find((SslBindingKey)null));
             Assert.That(ex.ParamName, Is.EqualTo("key"));
         }
 
         [Test]
-        public void QueryByUntypedIpKeyDispatchesToIpQuery()
+        public void FindByUntypedIpKeyDispatchesToIpFind()
         {
             var configuration = new SslBindingConfiguration();
 
-            IReadOnlyList<ISslBinding> result = configuration.Query((SslBindingKey)new IpPortKey(IPAddress.Any, 65535));
+            ISslBinding result = configuration.Find((SslBindingKey)new IpPortKey(IPAddress.Any, 65535));
 
-            Assert.That(result, Is.Empty);
+            Assert.That(result, Is.Null);
         }
 
         [Test]
-        public void QueryByUntypedHostnameKeyDispatchesToHostnameQuery()
+        public void FindByUntypedHostnameKeyDispatchesToHostnameFind()
         {
             var configuration = new SslBindingConfiguration();
 
-            IReadOnlyList<ISslBinding> result = configuration.Query((SslBindingKey)new HostnamePortKey("localhost", 65535));
+            ISslBinding result = configuration.Find((SslBindingKey)new HostnamePortKey("localhost", 65535));
 
-            Assert.That(result, Is.Empty);
+            Assert.That(result, Is.Null);
         }
 
         [Test]
-        public void QueryByCcsKeyRejectsNull()
+        public void FindByCcsKeyRejectsNull()
         {
             var configuration = new SslBindingConfiguration();
 
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => configuration.Query((CcsPortKey)null));
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => configuration.Find((CcsPortKey)null));
             Assert.That(ex.ParamName, Is.EqualTo("key"));
         }
 
         [Test]
-        public void QueryByScopedCcsKeyRejectsNull()
+        public void FindByScopedCcsKeyRejectsNull()
         {
             var configuration = new SslBindingConfiguration();
 
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => configuration.Query((ScopedCcsKey)null));
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => configuration.Find((ScopedCcsKey)null));
             Assert.That(ex.ParamName, Is.EqualTo("key"));
         }
 
         [Test]
-        public void QueryByUntypedCcsKeyDispatchesToCcsQuery()
+        public void FindByUntypedCcsKeyDispatchesToCcsFind()
         {
             var configuration = new SslBindingConfiguration();
 
-            IReadOnlyList<ISslBinding> result = configuration.Query((SslBindingKey)new CcsPortKey(65535));
+            ISslBinding result = configuration.Find((SslBindingKey)new CcsPortKey(65535));
 
-            Assert.That(result, Is.Empty);
+            Assert.That(result, Is.Null);
         }
 
         [Test]
-        public void QueryByUntypedScopedCcsKeyDispatchesToScopedCcsQuery()
+        public void FindByUntypedScopedCcsKeyDispatchesToScopedCcsFind()
         {
             var configuration = new SslBindingConfiguration();
 
-            IReadOnlyList<ISslBinding> result = configuration.Query((SslBindingKey)new ScopedCcsKey("localhost", 65535));
+            ISslBinding result = configuration.Find((SslBindingKey)new ScopedCcsKey("localhost", 65535));
 
-            Assert.That(result, Is.Empty);
+            Assert.That(result, Is.Null);
         }
 
         [Test]
-        public void QueryByIpEndPointUsesImplicitKeyConversion()
+        public void FindByIpEndPointUsesImplicitKeyConversion()
         {
             var configuration = new SslBindingConfiguration();
             var endPoint = new IPEndPoint(IPAddress.Any, 65535);
 
-            IReadOnlyList<IpPortBinding> result = configuration.Query(endPoint.ToSslBindingKey());
+            IpPortBinding result = configuration.Find(endPoint.ToSslBindingKey());
 
-            Assert.That(result, Is.Empty);
+            Assert.That(result, Is.Null);
         }
 
         [Test]
-        public void QueryByDnsEndPointUsesImplicitKeyConversion()
+        public void FindByDnsEndPointUsesImplicitKeyConversion()
         {
             var configuration = new SslBindingConfiguration();
             var endPoint = new DnsEndPoint("localhost", 65535);
 
-            IReadOnlyList<HostnamePortBinding> result = configuration.Query(endPoint.ToHostnamePortKey());
+            HostnamePortBinding result = configuration.Find(endPoint.ToHostnamePortKey());
 
-            Assert.That(result, Is.Empty);
+            Assert.That(result, Is.Null);
         }
 
         [Test]
-        public void QueryByDnsEndPointUsesScopedCcsKeyConversion()
+        public void FindByDnsEndPointUsesScopedCcsKeyConversion()
         {
             var configuration = new SslBindingConfiguration();
             var endPoint = new DnsEndPoint("localhost", 65535);
 
-            IReadOnlyList<ScopedCcsBinding> result = configuration.Query(endPoint.ToScopedCcsKey());
+            ScopedCcsBinding result = configuration.Find(endPoint.ToScopedCcsKey());
 
-            Assert.That(result, Is.Empty);
+            Assert.That(result, Is.Null);
         }
 
         [Test]
@@ -185,11 +185,11 @@ namespace SslCertBinding.Net.Tests
         }
 
         [Test]
-        public void QueryByUnsupportedKeyTypeThrows()
+        public void FindByUnsupportedKeyTypeThrows()
         {
             var configuration = new SslBindingConfiguration();
 
-            NotSupportedException ex = Assert.Throws<NotSupportedException>(() => configuration.Query(new UnsupportedBindingKey("unsupported")));
+            NotSupportedException ex = Assert.Throws<NotSupportedException>(() => configuration.Find(new UnsupportedBindingKey("unsupported")));
             Assert.That(ex.Message, Does.Contain(typeof(UnsupportedBindingKey).FullName));
         }
 
@@ -263,13 +263,13 @@ namespace SslCertBinding.Net.Tests
         }
 
         [Test]
-        public void QueryByHostnameKeyThrowsPlatformNotSupportedWhenSniIsNotSupported()
+        public void FindByHostnameKeyThrowsPlatformNotSupportedWhenSniIsNotSupported()
         {
             ConfigureUnsupportedSni();
             var configuration = new SslBindingConfiguration();
 
             Assert.That(
-                () => configuration.Query(new HostnamePortKey("localhost", 443)),
+                () => configuration.Find(new HostnamePortKey("localhost", 443)),
                 Throws.TypeOf<PlatformNotSupportedException>());
         }
 
@@ -322,13 +322,13 @@ namespace SslCertBinding.Net.Tests
         }
 
         [Test]
-        public void QueryByCcsKeyThrowsPlatformNotSupportedWhenCcsIsNotSupported()
+        public void FindByCcsKeyThrowsPlatformNotSupportedWhenCcsIsNotSupported()
         {
             ConfigureUnsupportedCcs();
             var configuration = new SslBindingConfiguration();
 
             Assert.That(
-                () => configuration.Query(new CcsPortKey(443)),
+                () => configuration.Find(new CcsPortKey(443)),
                 Throws.TypeOf<PlatformNotSupportedException>());
         }
 
@@ -391,13 +391,13 @@ namespace SslCertBinding.Net.Tests
         }
 
         [Test]
-        public void QueryByScopedCcsKeyThrowsPlatformNotSupportedWhenScopedCcsIsNotSupported()
+        public void FindByScopedCcsKeyThrowsPlatformNotSupportedWhenScopedCcsIsNotSupported()
         {
             ConfigureUnsupportedScopedCcs();
             var configuration = new SslBindingConfiguration();
 
             Assert.That(
-                () => configuration.Query(new ScopedCcsKey("localhost", 443)),
+                () => configuration.Find(new ScopedCcsKey("localhost", 443)),
                 Throws.TypeOf<PlatformNotSupportedException>());
         }
 

--- a/src/SslCertBinding.Net.Tests/Configuration/SslBindingConfigurationIntegrationTestBase.cs
+++ b/src/SslCertBinding.Net.Tests/Configuration/SslBindingConfigurationIntegrationTestBase.cs
@@ -182,18 +182,18 @@ namespace SslCertBinding.Net.Tests
             }
         }
 
-        protected static ISslBinding QuerySingleBinding(SslBindingConfiguration configuration, SslBindingKey key)
+        protected static ISslBinding FindSingleBinding(SslBindingConfiguration configuration, SslBindingKey key)
         {
             switch (key)
             {
                 case IpPortKey ipKey:
-                    return configuration.Query(ipKey).Single();
+                    return configuration.Find(ipKey);
                 case HostnamePortKey hostnameKey:
-                    return configuration.Query(hostnameKey).Single();
+                    return configuration.Find(hostnameKey);
                 case CcsPortKey ccsKey:
-                    return configuration.Query(ccsKey).Single();
+                    return configuration.Find(ccsKey);
                 case ScopedCcsKey scopedCcsKey:
-                    return configuration.Query(scopedCcsKey).Single();
+                    return configuration.Find(scopedCcsKey);
                 default:
                     throw new ArgumentOutOfRangeException(nameof(key));
             }

--- a/src/SslCertBinding.Net.Tests/Configuration/SslBindingConfigurationIntegrationTestBase.cs
+++ b/src/SslCertBinding.Net.Tests/Configuration/SslBindingConfigurationIntegrationTestBase.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using NUnit.Framework;
 using SslCertBinding.Net.Tests.Properties;
 
+#nullable disable
 namespace SslCertBinding.Net.Tests
 {
     [NonParallelizable]

--- a/src/SslCertBinding.Net.Tests/Configuration/SslBindingConfigurationQueryTests.cs
+++ b/src/SslCertBinding.Net.Tests/Configuration/SslBindingConfigurationQueryTests.cs
@@ -14,14 +14,14 @@ namespace SslCertBinding.Net.Tests
 #endif
     public class SslBindingConfigurationQueryIntegrationTests : SslBindingConfigurationIntegrationTestBase
     {
-        [TestCase(SslBindingKind.IpPort, "0.0.0.0", TestName = "QueryExistingBinding_IpPort_Ipv4Any")]
-        [TestCase(SslBindingKind.IpPort, "::", TestName = "QueryExistingBinding_IpPort_Ipv6Any")]
-        [TestCase(SslBindingKind.HostnamePort, "localhost", TestName = "QueryExistingBinding_HostnamePort_Localhost")]
-        [TestCase(SslBindingKind.HostnamePort, "ssl-cert-binding.net.com", TestName = "QueryExistingBinding_HostnamePort_CustomHostname")]
-        [TestCase(SslBindingKind.CcsPort, null, TestName = "QueryExistingBinding_CcsPort")]
-        [TestCase(SslBindingKind.ScopedCcs, "localhost", TestName = "QueryExistingBinding_ScopedCcs_Localhost")]
-        [TestCase(SslBindingKind.ScopedCcs, "ssl-cert-binding.net.com", TestName = "QueryExistingBinding_ScopedCcs_CustomHostname")]
-        public async Task QueryExistingBinding(SslBindingKind kind, string value)
+        [TestCase(SslBindingKind.IpPort, "0.0.0.0", TestName = "FindExistingBinding_IpPort_Ipv4Any")]
+        [TestCase(SslBindingKind.IpPort, "::", TestName = "FindExistingBinding_IpPort_Ipv6Any")]
+        [TestCase(SslBindingKind.HostnamePort, "localhost", TestName = "FindExistingBinding_HostnamePort_Localhost")]
+        [TestCase(SslBindingKind.HostnamePort, "ssl-cert-binding.net.com", TestName = "FindExistingBinding_HostnamePort_CustomHostname")]
+        [TestCase(SslBindingKind.CcsPort, null, TestName = "FindExistingBinding_CcsPort")]
+        [TestCase(SslBindingKind.ScopedCcs, "localhost", TestName = "FindExistingBinding_ScopedCcs_Localhost")]
+        [TestCase(SslBindingKind.ScopedCcs, "ssl-cert-binding.net.com", TestName = "FindExistingBinding_ScopedCcs_CustomHostname")]
+        public async Task FindExistingBinding(SslBindingKind kind, string value)
         {
             SslBindingKey key = await GetFreeBindingKey(kind, value);
             var appId = CreateTestAppId();
@@ -35,7 +35,7 @@ namespace SslCertBinding.Net.Tests
             });
 
             var configuration = new SslBindingConfiguration();
-            ISslBinding binding = QuerySingleBinding(configuration, key);
+            ISslBinding binding = FindSingleBinding(configuration, key);
 
             AssertBindingMatches(
                 binding,
@@ -45,14 +45,14 @@ namespace SslCertBinding.Net.Tests
                 kind == SslBindingKind.IpPort || kind == SslBindingKind.HostnamePort ? StoreName.My.ToString() : null);
         }
 
-        [TestCase(SslBindingKind.IpPort, "0.0.0.0", TestName = "QueryMissingBinding_IpPort_Ipv4Any")]
-        [TestCase(SslBindingKind.IpPort, "::", TestName = "QueryMissingBinding_IpPort_Ipv6Any")]
-        [TestCase(SslBindingKind.HostnamePort, "localhost", TestName = "QueryMissingBinding_HostnamePort_Localhost")]
-        [TestCase(SslBindingKind.HostnamePort, "ssl-cert-binding.net.com", TestName = "QueryMissingBinding_HostnamePort_CustomHostname")]
-        [TestCase(SslBindingKind.CcsPort, null, TestName = "QueryMissingBinding_CcsPort")]
-        [TestCase(SslBindingKind.ScopedCcs, "localhost", TestName = "QueryMissingBinding_ScopedCcs_Localhost")]
-        [TestCase(SslBindingKind.ScopedCcs, "ssl-cert-binding.net.com", TestName = "QueryMissingBinding_ScopedCcs_CustomHostname")]
-        public async Task QueryMissingBindingReturnsEmpty(SslBindingKind kind, string value)
+        [TestCase(SslBindingKind.IpPort, "0.0.0.0", TestName = "FindMissingBinding_IpPort_Ipv4Any")]
+        [TestCase(SslBindingKind.IpPort, "::", TestName = "FindMissingBinding_IpPort_Ipv6Any")]
+        [TestCase(SslBindingKind.HostnamePort, "localhost", TestName = "FindMissingBinding_HostnamePort_Localhost")]
+        [TestCase(SslBindingKind.HostnamePort, "ssl-cert-binding.net.com", TestName = "FindMissingBinding_HostnamePort_CustomHostname")]
+        [TestCase(SslBindingKind.CcsPort, null, TestName = "FindMissingBinding_CcsPort")]
+        [TestCase(SslBindingKind.ScopedCcs, "localhost", TestName = "FindMissingBinding_ScopedCcs_Localhost")]
+        [TestCase(SslBindingKind.ScopedCcs, "ssl-cert-binding.net.com", TestName = "FindMissingBinding_ScopedCcs_CustomHostname")]
+        public async Task FindMissingBindingReturnsNull(SslBindingKind kind, string value)
         {
             SslBindingKey key = await GetFreeBindingKey(kind, value);
             var configuration = new SslBindingConfiguration();
@@ -60,16 +60,16 @@ namespace SslCertBinding.Net.Tests
             switch (key)
             {
                 case IpPortKey ipKey:
-                    Assert.That(configuration.Query(ipKey), Is.Empty);
+                    Assert.That(configuration.Find(ipKey), Is.Null);
                     break;
                 case HostnamePortKey hostnameKey:
-                    Assert.That(configuration.Query(hostnameKey), Is.Empty);
+                    Assert.That(configuration.Find(hostnameKey), Is.Null);
                     break;
                 case CcsPortKey ccsKey:
-                    Assert.That(configuration.Query(ccsKey), Is.Empty);
+                    Assert.That(configuration.Find(ccsKey), Is.Null);
                     break;
                 case ScopedCcsKey scopedCcsKey:
-                    Assert.That(configuration.Query(scopedCcsKey), Is.Empty);
+                    Assert.That(configuration.Find(scopedCcsKey), Is.Null);
                     break;
                 default:
                     throw new ArgumentOutOfRangeException(nameof(kind));

--- a/src/SslCertBinding.Net.Tests/Configuration/SslBindingConfigurationQueryTests.cs
+++ b/src/SslCertBinding.Net.Tests/Configuration/SslBindingConfigurationQueryTests.cs
@@ -6,6 +6,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
+#nullable disable
 namespace SslCertBinding.Net.Tests
 {
     [TestFixture]

--- a/src/SslCertBinding.Net.Tests/Configuration/SslBindingConfigurationUpsertTests.cs
+++ b/src/SslCertBinding.Net.Tests/Configuration/SslBindingConfigurationUpsertTests.cs
@@ -104,7 +104,7 @@ namespace SslCertBinding.Net.Tests
 
             configuration.Upsert(new CcsPortBinding(key, appId));
 
-            CcsPortBinding binding = configuration.Query(key).Single();
+            CcsPortBinding binding = configuration.Find(key);
             AssertBindingMatches(binding, key, appId, new BindingOptions(), null);
         }
 
@@ -122,7 +122,7 @@ namespace SslCertBinding.Net.Tests
                 DisableTls12 = true,
             }));
 
-            ScopedCcsBinding binding = configuration.Query(key).Single();
+            ScopedCcsBinding binding = configuration.Find(key);
             AssertBindingMatches(binding, key, appId, new BindingOptions
             {
                 UseDsMappers = true,
@@ -207,7 +207,7 @@ namespace SslCertBinding.Net.Tests
             var configuration = new SslBindingConfiguration();
             configuration.Upsert(CreateBinding(key, updatedAppId, expectedOptions));
 
-            ISslBinding binding = QuerySingleBinding(configuration, key);
+            ISslBinding binding = FindSingleBinding(configuration, key);
             AssertBindingMatches(
                 binding,
                 key,
@@ -225,7 +225,7 @@ namespace SslCertBinding.Net.Tests
 
             configuration.Upsert(CreateBinding(key, appId, expectedOptions));
 
-            ISslBinding binding = QuerySingleBinding(configuration, key);
+            ISslBinding binding = FindSingleBinding(configuration, key);
 
             Assert.Multiple(() =>
             {

--- a/src/SslCertBinding.Net.Tests/Configuration/SslBindingConfigurationUpsertTests.cs
+++ b/src/SslCertBinding.Net.Tests/Configuration/SslBindingConfigurationUpsertTests.cs
@@ -5,6 +5,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using NUnit.Framework;
 
+#nullable disable
 namespace SslCertBinding.Net.Tests
 {
     [TestFixture]

--- a/src/SslCertBinding.Net.Tests/Helpers/CertConfigCmd.cs
+++ b/src/SslCertBinding.Net.Tests/Helpers/CertConfigCmd.cs
@@ -15,7 +15,7 @@ namespace SslCertBinding.Net.Tests
         {
             public int ExitCode { get; set; }
 
-            public string Output { get; set; }
+            public string Output { get; set; } = string.Empty;
 
             public bool IsSuccessfull
             {
@@ -27,18 +27,18 @@ namespace SslCertBinding.Net.Tests
         {
 #pragma warning disable CA1051 // Do not declare visible instance fields
 #pragma warning disable CS0649 // Test option bag fields are populated selectively by tests.
-            public SslBindingKey key;
-            public IPEndPoint ipport;
-            public string certhash;
+            public SslBindingKey? key;
+            public IPEndPoint? ipport;
+            public string? certhash;
             public Guid appid;
-            public string certstorename;
+            public string? certstorename;
             public bool? verifyclientcertrevocation;
             public bool? verifyrevocationwithcachedclientcertonly;
             public bool? usagecheck;
             public int? revocationfreshnesstime;
             public int? urlretrievaltimeout;
-            public string sslctlidentifier;
-            public string sslctlstorename;
+            public string? sslctlidentifier;
+            public string? sslctlstorename;
             public bool? dsmapperusage;
             public bool? clientcertnegotiation;
 #pragma warning restore CS0649 // Test option bag fields are populated selectively by tests.
@@ -47,22 +47,22 @@ namespace SslCertBinding.Net.Tests
 
         public sealed class BindingRecord
         {
-            public SslBindingKey Key { get; set; }
+            public SslBindingKey Key { get; set; } = null!;
 
             public Guid AppId { get; set; }
         }
 
-        public static Task<CommandResult> Show(IPEndPoint ipPort = null, bool throwExcepton = false)
+        public static Task<CommandResult> Show(IPEndPoint? ipPort = null, bool throwExcepton = false)
         {
-            return Show(ipPort == null ? (SslBindingKey)null : new IpPortKey(ipPort), throwExcepton);
+            return Show(ipPort == null ? (SslBindingKey?)null : new IpPortKey(ipPort), throwExcepton);
         }
 
-        public static Task<CommandResult> Show(SslBindingKey key, bool throwExcepton = false)
+        public static Task<CommandResult> Show(SslBindingKey? key, bool throwExcepton = false)
         {
             var sb = new StringBuilder("http show sslcert");
             if (key != null)
             {
-                AppendArgument(sb, GetArgumentName(key.Kind), key.ToString());
+                AppendArgument(sb, GetArgumentName(key.Kind), key.ToString() ?? string.Empty);
             }
 
             return ExecCommand(sb.ToString(), throwExcepton);
@@ -89,13 +89,13 @@ namespace SslCertBinding.Net.Tests
             _ = options ?? throw new ArgumentNullException(nameof(options));
 
             var sb = new StringBuilder("http add sslcert");
-            SslBindingKey key = options.key ?? (options.ipport == null ? null : new IpPortKey(options.ipport));
+            SslBindingKey? key = options.key ?? (options.ipport == null ? null : new IpPortKey(options.ipport));
             bool expectsCertificate = key == null
                 || key.Kind == SslBindingKind.IpPort
                 || key.Kind == SslBindingKind.HostnamePort;
             if (key != null)
             {
-                AppendArgument(sb, GetArgumentName(key.Kind), key.ToString());
+                AppendArgument(sb, GetArgumentName(key.Kind), key.ToString() ?? string.Empty);
                 if (key.Kind == SslBindingKind.HostnamePort && string.IsNullOrEmpty(options.certstorename))
                 {
                     options.certstorename = "MY";
@@ -103,11 +103,11 @@ namespace SslCertBinding.Net.Tests
             }
 
             if (expectsCertificate && !string.IsNullOrEmpty(options.certhash))
-                AppendArgument(sb, "certhash", options.certhash);
+                AppendArgument(sb, "certhash", options.certhash!);
             if (options.appid != Guid.Empty)
                 AppendArgument(sb, "appid", options.appid.ToString("B"));
             if (expectsCertificate && !string.IsNullOrEmpty(options.certstorename))
-                AppendArgument(sb, "certstorename", options.certstorename);
+                AppendArgument(sb, "certstorename", options.certstorename!);
             if (options.verifyclientcertrevocation.HasValue)
                 AppendArgument(sb, "verifyclientcertrevocation", BoolToEnableDisable(options.verifyclientcertrevocation.Value));
             if (options.verifyrevocationwithcachedclientcertonly.HasValue)
@@ -119,9 +119,9 @@ namespace SslCertBinding.Net.Tests
             if (options.urlretrievaltimeout.HasValue)
                 AppendArgument(sb, "urlretrievaltimeout", options.urlretrievaltimeout.Value.ToString(CultureInfo.InvariantCulture));
             if (!string.IsNullOrEmpty(options.sslctlidentifier))
-                AppendArgument(sb, "sslctlidentifier", options.sslctlidentifier);
+                AppendArgument(sb, "sslctlidentifier", options.sslctlidentifier!);
             if (!string.IsNullOrEmpty(options.sslctlstorename))
-                AppendArgument(sb, "sslctlstorename", options.sslctlstorename);
+                AppendArgument(sb, "sslctlstorename", options.sslctlstorename!);
             if (options.dsmapperusage.HasValue)
                 AppendArgument(sb, "dsmapperusage", BoolToEnableDisable(options.dsmapperusage.Value));
             if (options.clientcertnegotiation.HasValue)
@@ -152,7 +152,7 @@ namespace SslCertBinding.Net.Tests
             }
         }
 
-        public static async Task<IPEndPoint[]> GetIpEndPoints(string thumbprint = null)
+        public static async Task<IPEndPoint[]> GetIpEndPoints(string? thumbprint = null)
         {
             return (await GetBindingKeys(thumbprint))
                 .OfType<IpPortKey>()
@@ -160,14 +160,14 @@ namespace SslCertBinding.Net.Tests
                 .ToArray();
         }
 
-        public static async Task<SslBindingKey[]> GetBindingKeys(string thumbprint = null)
+        public static async Task<SslBindingKey[]> GetBindingKeys(string? thumbprint = null)
         {
             if (string.IsNullOrEmpty(thumbprint))
             {
                 return (await GetBindingRecords()).Select(record => record.Key).ToArray();
             }
 
-            CommandResult result = await Show((SslBindingKey)null, throwExcepton: true);
+            CommandResult result = await Show((SslBindingKey?)null, throwExcepton: true);
             string pattern = string.Format(
                 CultureInfo.InvariantCulture,
                 @"\s+(IP|Hostname):port\s+:\s+(\S+?)\s+Certificate Hash\s+:\s+{0}\s+",
@@ -185,10 +185,10 @@ namespace SslCertBinding.Net.Tests
 
         public static async Task<BindingRecord[]> GetBindingRecords()
         {
-            CommandResult result = await Show((SslBindingKey)null, throwExcepton: true);
-            Match keyRegex = null;
+            CommandResult result = await Show((SslBindingKey?)null, throwExcepton: true);
+            Match? keyRegex = null;
             var records = new System.Collections.Generic.List<BindingRecord>();
-            SslBindingKey currentKey = null;
+            SslBindingKey? currentKey = null;
             Guid? currentAppId = null;
 
             foreach (string line in Regex.Split(result.Output, @"\r?\n"))

--- a/src/SslCertBinding.Net.Tests/Interop/BindingKeyParserTests.cs
+++ b/src/SslCertBinding.Net.Tests/Interop/BindingKeyParserTests.cs
@@ -30,16 +30,16 @@ namespace SslCertBinding.Net.Tests
         [TestCase("[2001:db8::1] :443 ", false, null, 0, TestName = "TryParseIpPort_WhitespaceBeforeSeparatorRejected")]
         [TestCase("[2001:db8::1]: 443 ", false, null, 0, TestName = "TryParseIpPort_WhitespaceAfterSeparatorRejected")]
         [TestCase("[2001:db8::1]:443", true, "2001:db8::1", 443, TestName = "TryParseIpPort_BracketedIpv6Accepted")]
-        public void TryParseIpPortHandlesExpectedCases(string value, bool expectedResult, string expectedAddress, int expectedPort)
+        public void TryParseIpPortHandlesExpectedCases(string? value, bool expectedResult, string? expectedAddress, int expectedPort)
         {
-            object[] parameters = { value, null, 0 };
+            object?[] parameters = { value, null, 0 };
             bool result = (bool)InvokeBindingKeyParser("TryParseIpPort", parameters);
 
             Assert.Multiple(() =>
             {
                 Assert.That(result, Is.EqualTo(expectedResult));
                 Assert.That(parameters[1] as IPAddress, Is.EqualTo(expectedAddress == null ? null : IPAddress.Parse(expectedAddress)));
-                Assert.That((int)parameters[2], Is.EqualTo(expectedPort));
+                Assert.That(parameters[2], Is.EqualTo(expectedPort));
             });
         }
 
@@ -56,24 +56,24 @@ namespace SslCertBinding.Net.Tests
         [TestCase("  www.contoso.com :443  ", false, null, 0, TestName = "TryParseHostPort_WhitespaceBeforeSeparatorRejected")]
         [TestCase("  www.contoso.com: 443  ", false, null, 0, TestName = "TryParseHostPort_WhitespaceAfterSeparatorRejected")]
         [TestCase("*.example.com:443", true, "*.example.com", 443, TestName = "TryParseHostPort_WildcardAccepted")]
-        public void TryParseHostPortHandlesExpectedCases(string value, bool expectedResult, string expectedHost, int expectedPort)
+        public void TryParseHostPortHandlesExpectedCases(string? value, bool expectedResult, string? expectedHost, int expectedPort)
         {
-            object[] parameters = { value, null, 0 };
+            object?[] parameters = { value, null, 0 };
             bool result = (bool)InvokeBindingKeyParser("TryParseHostPort", parameters);
 
             Assert.Multiple(() =>
             {
                 Assert.That(result, Is.EqualTo(expectedResult));
                 Assert.That(parameters[1] as string, Is.EqualTo(expectedHost));
-                Assert.That((int)parameters[2], Is.EqualTo(expectedPort));
+                Assert.That(parameters[2], Is.EqualTo(expectedPort));
             });
         }
 
-        private static object InvokeBindingKeyParser(string methodName, params object[] parameters)
+        private static object InvokeBindingKeyParser(string methodName, params object?[] parameters)
         {
-            Type parserType = typeof(SslBindingConfiguration).Assembly.GetType("SslCertBinding.Net.Internal.BindingKeyParser", throwOnError: true);
-            MethodInfo method = parserType.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static);
-            return method.Invoke(null, parameters);
+            Type parserType = typeof(SslBindingConfiguration).Assembly.GetType("SslCertBinding.Net.Internal.BindingKeyParser", throwOnError: true)!;
+            MethodInfo method = parserType.GetMethod(methodName, BindingFlags.Public | BindingFlags.Static)!;
+            return method.Invoke(null, parameters)!;
         }
     }
 }

--- a/src/SslCertBinding.Net.Tests/Interop/HttpApiLinuxTests.cs
+++ b/src/SslCertBinding.Net.Tests/Interop/HttpApiLinuxTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Reflection;
 using NUnit.Framework;
 
+#nullable disable
 namespace SslCertBinding.Net.Tests
 {
     [TestFixture]

--- a/src/SslCertBinding.Net.Tests/Interop/HttpApiTests.cs
+++ b/src/SslCertBinding.Net.Tests/Interop/HttpApiTests.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Reflection;
 using NUnit.Framework;
 
+#nullable disable
 namespace SslCertBinding.Net.Tests
 {
     [TestFixture]

--- a/src/SslCertBinding.Net.Tests/Interop/SockaddrInteropTests.cs
+++ b/src/SslCertBinding.Net.Tests/Interop/SockaddrInteropTests.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using NUnit.Framework;
 
+#nullable disable
 namespace SslCertBinding.Net.Tests
 {
     [TestFixture]

--- a/src/SslCertBinding.Net.Tests/Model/SslBindingKeyContractTests.cs
+++ b/src/SslCertBinding.Net.Tests/Model/SslBindingKeyContractTests.cs
@@ -24,11 +24,12 @@ namespace SslCertBinding.Net.Tests
         [Test]
         public void GenericTryParseSupportsHostnameKind()
         {
-            bool result = SslBindingKey.TryParse("www.contoso.com:443", SslBindingKind.HostnamePort, out SslBindingKey key);
+            bool result = SslBindingKey.TryParse("www.contoso.com:443", SslBindingKind.HostnamePort, out SslBindingKey? key);
 
             Assert.Multiple(() =>
             {
                 Assert.That(result, Is.True);
+                Assert.That(key, Is.Not.Null);
                 Assert.That(key, Is.TypeOf<HostnamePortKey>());
             });
         }
@@ -36,11 +37,12 @@ namespace SslCertBinding.Net.Tests
         [Test]
         public void GenericTryParseSupportsIpKind()
         {
-            bool result = SslBindingKey.TryParse("127.0.0.1:443", SslBindingKind.IpPort, out SslBindingKey key);
+            bool result = SslBindingKey.TryParse("127.0.0.1:443", SslBindingKind.IpPort, out SslBindingKey? key);
 
             Assert.Multiple(() =>
             {
                 Assert.That(result, Is.True);
+                Assert.That(key, Is.Not.Null);
                 Assert.That(key, Is.TypeOf<IpPortKey>());
             });
         }
@@ -48,11 +50,12 @@ namespace SslCertBinding.Net.Tests
         [Test]
         public void GenericTryParseSupportsCcsKind()
         {
-            bool result = SslBindingKey.TryParse("443", SslBindingKind.CcsPort, out SslBindingKey key);
+            bool result = SslBindingKey.TryParse("443", SslBindingKind.CcsPort, out SslBindingKey? key);
 
             Assert.Multiple(() =>
             {
                 Assert.That(result, Is.True);
+                Assert.That(key, Is.Not.Null);
                 Assert.That(key, Is.TypeOf<CcsPortKey>());
             });
         }
@@ -60,11 +63,12 @@ namespace SslCertBinding.Net.Tests
         [Test]
         public void GenericTryParseSupportsScopedCcsKind()
         {
-            bool result = SslBindingKey.TryParse("www.contoso.com:443", SslBindingKind.ScopedCcs, out SslBindingKey key);
+            bool result = SslBindingKey.TryParse("www.contoso.com:443", SslBindingKind.ScopedCcs, out SslBindingKey? key);
 
             Assert.Multiple(() =>
             {
                 Assert.That(result, Is.True);
+                Assert.That(key, Is.Not.Null);
                 Assert.That(key, Is.TypeOf<ScopedCcsKey>());
             });
         }
@@ -72,7 +76,7 @@ namespace SslCertBinding.Net.Tests
         [Test]
         public void GenericTryParseReturnsFalseForInvalidHostnameValue()
         {
-            bool result = SslBindingKey.TryParse("localhost", SslBindingKind.HostnamePort, out SslBindingKey key);
+            bool result = SslBindingKey.TryParse("localhost", SslBindingKind.HostnamePort, out SslBindingKey? key);
 
             Assert.Multiple(() =>
             {
@@ -87,14 +91,15 @@ namespace SslCertBinding.Net.Tests
             var endPoint = new IPEndPoint(IPAddress.Parse("127.0.0.1"), 8443);
 
             IpPortKey key = IpPortKey.From(endPoint);
-            IpPortKey implicitKey = endPoint;
+            IpPortKey? implicitKey = endPoint;
 
             Assert.Multiple(() =>
             {
+                Assert.That(implicitKey, Is.Not.Null);
                 Assert.That(key.Equals(endPoint), Is.True);
                 Assert.That(key.Equals((object)endPoint), Is.True);
                 Assert.That(key.Equals(implicitKey), Is.True);
-                Assert.That(key.GetHashCode(), Is.EqualTo(implicitKey.GetHashCode()));
+                Assert.That(key.GetHashCode(), Is.EqualTo(implicitKey!.GetHashCode()));
             });
         }
 
@@ -103,7 +108,7 @@ namespace SslCertBinding.Net.Tests
         {
             Assert.Multiple(() =>
             {
-                Assert.That(IpPortKey.TryParse("localhost:443", out IpPortKey key), Is.False);
+                Assert.That(IpPortKey.TryParse("localhost:443", out IpPortKey? key), Is.False);
                 Assert.That(key, Is.Null);
                 Assert.That(() => IpPortKey.Parse("localhost:443"), Throws.TypeOf<FormatException>());
             });
@@ -112,7 +117,9 @@ namespace SslCertBinding.Net.Tests
         [Test]
         public void IpPortKeyParseRejectsNullValue()
         {
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => IpPortKey.Parse(null));
+            string? value = null;
+
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => IpPortKey.Parse(value!));
             Assert.That(ex.ParamName, Is.EqualTo("value"));
         }
 
@@ -128,20 +135,23 @@ namespace SslCertBinding.Net.Tests
         public void IpPortKeyTypedEqualityRejectsNullValues()
         {
             var key = new IpPortKey(IPAddress.Any, 443);
+            IpPortKey? otherKey = null;
+            IPEndPoint? endPoint = null;
 
             Assert.Multiple(() =>
             {
-                Assert.That(key.Equals((IpPortKey)null), Is.False);
-                Assert.That(key.Equals((IPEndPoint)null), Is.False);
+                Assert.That(key.Equals(otherKey), Is.False);
+                Assert.That(key.Equals(endPoint), Is.False);
             });
         }
 
         [Test]
         public void IpPortKeyNullImplicitConversionReturnsNullEndPoint()
         {
-            IpPortKey key = null;
+            IpPortKey? key = null;
+            IPEndPoint? endPoint = key;
 
-            Assert.That((IPEndPoint)key, Is.Null);
+            Assert.That(endPoint, Is.Null);
         }
 
         [Test]
@@ -150,14 +160,15 @@ namespace SslCertBinding.Net.Tests
             var endPoint = new DnsEndPoint("www.contoso.com", 8443);
 
             HostnamePortKey key = HostnamePortKey.From(endPoint);
-            HostnamePortKey implicitKey = endPoint;
+            HostnamePortKey? implicitKey = endPoint;
 
             Assert.Multiple(() =>
             {
+                Assert.That(implicitKey, Is.Not.Null);
                 Assert.That(key.Equals(endPoint), Is.True);
                 Assert.That(key.Equals((object)endPoint), Is.True);
                 Assert.That(key.Equals(implicitKey), Is.True);
-                Assert.That(key.GetHashCode(), Is.EqualTo(implicitKey.GetHashCode()));
+                Assert.That(key.GetHashCode(), Is.EqualTo(implicitKey!.GetHashCode()));
             });
         }
 
@@ -213,7 +224,7 @@ namespace SslCertBinding.Net.Tests
         {
             Assert.Multiple(() =>
             {
-                Assert.That(HostnamePortKey.TryParse("127.0.0.1:443", out HostnamePortKey key), Is.False);
+                Assert.That(HostnamePortKey.TryParse("127.0.0.1:443", out HostnamePortKey? key), Is.False);
                 Assert.That(key, Is.Null);
                 Assert.That(() => HostnamePortKey.Parse("127.0.0.1:443"), Throws.TypeOf<FormatException>());
             });
@@ -222,14 +233,16 @@ namespace SslCertBinding.Net.Tests
         [Test]
         public void HostnamePortKeyParseRejectsNullValue()
         {
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => HostnamePortKey.Parse(null));
+            string? value = null;
+
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => HostnamePortKey.Parse(value!));
             Assert.That(ex.ParamName, Is.EqualTo("value"));
         }
 
         [Test]
         public void HostnamePortKeyTryParseReturnsFalseForMalformedValue()
         {
-            bool result = HostnamePortKey.TryParse("localhost", out HostnamePortKey key);
+            bool result = HostnamePortKey.TryParse("localhost", out HostnamePortKey? key);
 
             Assert.Multiple(() =>
             {
@@ -241,14 +254,18 @@ namespace SslCertBinding.Net.Tests
         [Test]
         public void HostnamePortKeyConstructorRejectsNullDnsEndPoint()
         {
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => new HostnamePortKey((DnsEndPoint)null));
+            DnsEndPoint? endPoint = null;
+
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => new HostnamePortKey(endPoint!));
             Assert.That(ex.ParamName, Is.EqualTo("endPoint"));
         }
 
         [Test]
         public void HostnamePortKeyConstructorRejectsNullHostname()
         {
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => new HostnamePortKey((string)null, 443));
+            string? hostname = null;
+
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => new HostnamePortKey(hostname!, 443));
             Assert.That(ex.ParamName, Is.EqualTo("hostname"));
         }
 
@@ -264,20 +281,23 @@ namespace SslCertBinding.Net.Tests
         public void HostnamePortKeyTypedEqualityRejectsNullValues()
         {
             var key = new HostnamePortKey("www.contoso.com", 443);
+            HostnamePortKey? otherKey = null;
+            DnsEndPoint? endPoint = null;
 
             Assert.Multiple(() =>
             {
-                Assert.That(key.Equals((HostnamePortKey)null), Is.False);
-                Assert.That(key.Equals((DnsEndPoint)null), Is.False);
+                Assert.That(key.Equals(otherKey), Is.False);
+                Assert.That(key.Equals(endPoint), Is.False);
             });
         }
 
         [Test]
         public void HostnamePortKeyNullImplicitConversionReturnsNullEndPoint()
         {
-            HostnamePortKey key = null;
+            HostnamePortKey? key = null;
+            DnsEndPoint? endPoint = key;
 
-            Assert.That((DnsEndPoint)key, Is.Null);
+            Assert.That(endPoint, Is.Null);
         }
 
         [Test]
@@ -293,7 +313,7 @@ namespace SslCertBinding.Net.Tests
         {
             Assert.Multiple(() =>
             {
-                Assert.That(CcsPortKey.TryParse("localhost:443", out CcsPortKey key), Is.False);
+                Assert.That(CcsPortKey.TryParse("localhost:443", out CcsPortKey? key), Is.False);
                 Assert.That(key, Is.Null);
                 Assert.That(() => CcsPortKey.Parse("localhost:443"), Throws.TypeOf<FormatException>());
             });
@@ -302,7 +322,9 @@ namespace SslCertBinding.Net.Tests
         [Test]
         public void CcsPortKeyParseRejectsNullValue()
         {
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => CcsPortKey.Parse(null));
+            string? value = null;
+
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => CcsPortKey.Parse(value!));
             Assert.That(ex.ParamName, Is.EqualTo("value"));
         }
 
@@ -346,14 +368,15 @@ namespace SslCertBinding.Net.Tests
             var endPoint = new DnsEndPoint("www.contoso.com", 8443);
 
             ScopedCcsKey key = ScopedCcsKey.From(endPoint);
-            ScopedCcsKey implicitKey = endPoint;
+            ScopedCcsKey? implicitKey = endPoint;
 
             Assert.Multiple(() =>
             {
+                Assert.That(implicitKey, Is.Not.Null);
                 Assert.That(key.Equals(endPoint), Is.True);
                 Assert.That(key.Equals((object)endPoint), Is.True);
                 Assert.That(key.Equals(implicitKey), Is.True);
-                Assert.That(key.GetHashCode(), Is.EqualTo(implicitKey.GetHashCode()));
+                Assert.That(key.GetHashCode(), Is.EqualTo(implicitKey!.GetHashCode()));
             });
         }
 
@@ -409,7 +432,7 @@ namespace SslCertBinding.Net.Tests
         {
             Assert.Multiple(() =>
             {
-                Assert.That(ScopedCcsKey.TryParse("127.0.0.1:443", out ScopedCcsKey key), Is.False);
+                Assert.That(ScopedCcsKey.TryParse("127.0.0.1:443", out ScopedCcsKey? key), Is.False);
                 Assert.That(key, Is.Null);
                 Assert.That(() => ScopedCcsKey.Parse("127.0.0.1:443"), Throws.TypeOf<FormatException>());
             });
@@ -418,7 +441,9 @@ namespace SslCertBinding.Net.Tests
         [Test]
         public void ScopedCcsKeyParseRejectsNullValue()
         {
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => ScopedCcsKey.Parse(null));
+            string? value = null;
+
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => ScopedCcsKey.Parse(value!));
             Assert.That(ex.ParamName, Is.EqualTo("value"));
         }
 
@@ -438,7 +463,7 @@ namespace SslCertBinding.Net.Tests
         [Test]
         public void ScopedCcsKeyTryParseReturnsFalseForMalformedValue()
         {
-            bool result = ScopedCcsKey.TryParse("localhost", out ScopedCcsKey key);
+            bool result = ScopedCcsKey.TryParse("localhost", out ScopedCcsKey? key);
 
             Assert.Multiple(() =>
             {
@@ -450,14 +475,18 @@ namespace SslCertBinding.Net.Tests
         [Test]
         public void ScopedCcsKeyConstructorRejectsNullDnsEndPoint()
         {
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => new ScopedCcsKey((DnsEndPoint)null));
+            DnsEndPoint? endPoint = null;
+
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => new ScopedCcsKey(endPoint!));
             Assert.That(ex.ParamName, Is.EqualTo("endPoint"));
         }
 
         [Test]
         public void ScopedCcsKeyConstructorRejectsNullHostname()
         {
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => new ScopedCcsKey((string)null, 443));
+            string? hostname = null;
+
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => new ScopedCcsKey(hostname!, 443));
             Assert.That(ex.ParamName, Is.EqualTo("hostname"));
         }
 
@@ -473,33 +502,40 @@ namespace SslCertBinding.Net.Tests
         public void ScopedCcsKeyTypedEqualityRejectsNullValues()
         {
             var key = new ScopedCcsKey("www.contoso.com", 443);
+            ScopedCcsKey? otherKey = null;
+            DnsEndPoint? endPoint = null;
 
             Assert.Multiple(() =>
             {
-                Assert.That(key.Equals((ScopedCcsKey)null), Is.False);
-                Assert.That(key.Equals((DnsEndPoint)null), Is.False);
+                Assert.That(key.Equals(otherKey), Is.False);
+                Assert.That(key.Equals(endPoint), Is.False);
             });
         }
 
         [Test]
         public void ScopedCcsKeyNullImplicitConversionReturnsNullEndPoint()
         {
-            ScopedCcsKey key = null;
+            ScopedCcsKey? key = null;
+            DnsEndPoint? endPoint = key;
 
-            Assert.That((DnsEndPoint)key, Is.Null);
+            Assert.That(endPoint, Is.Null);
         }
 
         [Test]
         public void IpPortKeyConstructorRejectsNullIpEndPoint()
         {
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => new IpPortKey((IPEndPoint)null));
+            IPEndPoint? endPoint = null;
+
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => new IpPortKey(endPoint!));
             Assert.That(ex.ParamName, Is.EqualTo("endPoint"));
         }
 
         [Test]
         public void IpPortKeyConstructorRejectsNullAddress()
         {
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => new IpPortKey((IPAddress)null, 443));
+            IPAddress? address = null;
+
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => new IpPortKey(address!, 443));
             Assert.That(ex.ParamName, Is.EqualTo("address"));
         }
 

--- a/src/SslCertBinding.Net.Tests/Model/SslBindingKeyTests.cs
+++ b/src/SslCertBinding.Net.Tests/Model/SslBindingKeyTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Net;
 using NUnit.Framework;
 
+#nullable disable
 namespace SslCertBinding.Net.Tests
 {
     [TestFixture]

--- a/src/SslCertBinding.Net.Tests/Model/SslBindingKeyTests.cs
+++ b/src/SslCertBinding.Net.Tests/Model/SslBindingKeyTests.cs
@@ -24,11 +24,11 @@ namespace SslCertBinding.Net.Tests
         }
 
         [Test]
-        public void IpEndPointToSslBindingKeyReturnsIpPortKey()
+        public void IpEndPointToIpPortKeyReturnsIpPortKey()
         {
             var endPoint = new IPEndPoint(IPAddress.Parse("0.0.0.0"), 443);
 
-            IpPortKey key = endPoint.ToSslBindingKey();
+            IpPortKey key = endPoint.ToIpPortKey();
 
             Assert.Multiple(() =>
             {

--- a/src/SslCertBinding.Net.Tests/Model/SslBindingTests.cs
+++ b/src/SslCertBinding.Net.Tests/Model/SslBindingTests.cs
@@ -61,22 +61,35 @@ namespace SslCertBinding.Net.Tests
         [Test]
         public void SslCertificateReferenceDefaultsStoreNameToMyWhenNull()
         {
-            var reference = new SslCertificateReference("thumbprint", (string)null);
+            var reference = new SslCertificateReference("thumbprint");
 
             Assert.That(reference.StoreName, Is.EqualTo("MY"));
         }
 
         [Test]
+        public void SslCertificateReferenceRejectsNullStoreName()
+        {
+            string? storeName = null;
+
+            ArgumentException ex = Assert.Throws<ArgumentException>(() => new SslCertificateReference("thumbprint", storeName!));
+            Assert.That(ex.ParamName, Is.EqualTo("storeName"));
+        }
+
+        [Test]
         public void SslCertificateReferenceFromCertificateAndStoreNameRejectsNullCertificate()
         {
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => SslCertificateReference.From((X509Certificate2)null, StoreName.My));
+            X509Certificate2? certificate = null;
+
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => SslCertificateReference.From(certificate!, StoreName.My));
             Assert.That(ex.ParamName, Is.EqualTo("certificate"));
         }
 
         [Test]
         public void SslCertificateReferenceFromCertificateAndStringStoreRejectsNullCertificate()
         {
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => SslCertificateReference.From((X509Certificate2)null, "MY"));
+            X509Certificate2? certificate = null;
+
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => SslCertificateReference.From(certificate!, "MY"));
             Assert.That(ex.ParamName, Is.EqualTo("certificate"));
         }
 
@@ -97,9 +110,10 @@ namespace SslCertBinding.Net.Tests
         [Test]
         public void SafeInteropResultDisposeWithNullDisposeActionsDoesNotThrow()
         {
+            Action? disposeAction = null;
             var result = new SafeInteropResult<HttpApi.HTTP_SERVICE_CONFIG_SSL_KEY>(
                 new HttpApi.HTTP_SERVICE_CONFIG_SSL_KEY(IntPtr.Zero),
-                null);
+                disposeAction!);
 
             Assert.That(() => result.Dispose(), Throws.Nothing);
         }
@@ -107,9 +121,11 @@ namespace SslCertBinding.Net.Tests
         [Test]
         public void IpPortBindingRejectsNullKey()
         {
+            IpPortKey? key = null;
+
             void Constructor()
             {
-                _ = new IpPortBinding(null, new SslCertificateReference("thumbprint", "MY"), Guid.Empty);
+                _ = new IpPortBinding(key!, new SslCertificateReference("thumbprint", "MY"), Guid.Empty);
             }
 
             ArgumentNullException ex = Assert.Throws<ArgumentNullException>(Constructor);
@@ -186,7 +202,9 @@ namespace SslCertBinding.Net.Tests
         [Test]
         public void CcsPortBindingRejectsNullKey()
         {
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => new CcsPortBinding(null, Guid.Empty));
+            CcsPortKey? key = null;
+
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => new CcsPortBinding(key!, Guid.Empty));
             Assert.That(ex.ParamName, Is.EqualTo("key"));
         }
 
@@ -206,7 +224,9 @@ namespace SslCertBinding.Net.Tests
         [Test]
         public void ScopedCcsBindingRejectsNullKey()
         {
-            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => new ScopedCcsBinding(null, Guid.Empty));
+            ScopedCcsKey? key = null;
+
+            ArgumentNullException ex = Assert.Throws<ArgumentNullException>(() => new ScopedCcsBinding(key!, Guid.Empty));
             Assert.That(ex.ParamName, Is.EqualTo("key"));
         }
     }

--- a/src/SslCertBinding.Net/BindingOptions.cs
+++ b/src/SslCertBinding.Net/BindingOptions.cs
@@ -21,13 +21,15 @@ namespace SslCertBinding.Net
         /// <summary>
         /// The SSL control identifier, which specifies the list of the certificate issuers that can be trusted.
         /// This list can be a subset of the certificate issuers that are trusted by the computer.
+        /// A <c>null</c> value means no explicit SSL control identifier is configured.
         /// </summary>
-        public string SslCtlIdentifier { get; set; }
+        public string? SslCtlIdentifier { get; set; }
 
         /// <summary>
         /// The name of the store under the Local Machine store location where the control identifier pointed to by <see cref="SslCtlIdentifier"/> is stored.
+        /// A <c>null</c> value means no explicit SSL control store is configured.
         /// </summary>
-        public string SslCtlStoreName { get; set; }
+        public string? SslCtlStoreName { get; set; }
 
         /// <summary>
         /// Indicates whether client certificates are mapped where possible to corresponding operating-system user accounts based on the certificate mapping rules stored in Active Directory.

--- a/src/SslCertBinding.Net/Bindings/CcsPortBinding.cs
+++ b/src/SslCertBinding.Net/Bindings/CcsPortBinding.cs
@@ -13,7 +13,7 @@ namespace SslCertBinding.Net
         /// <param name="key">The CCS binding key.</param>
         /// <param name="appId">The application identifier.</param>
         /// <param name="options">The binding options.</param>
-        public CcsPortBinding(CcsPortKey key, Guid appId, BindingOptions options = null)
+        public CcsPortBinding(CcsPortKey key, Guid appId, BindingOptions? options = null)
             : base(appId, options)
         {
             Key = key ?? throw new ArgumentNullException(nameof(key));

--- a/src/SslCertBinding.Net/Bindings/HostnamePortBinding.cs
+++ b/src/SslCertBinding.Net/Bindings/HostnamePortBinding.cs
@@ -14,8 +14,8 @@ namespace SslCertBinding.Net
         /// <param name="certificateThumbprint">The thumbprint of the bound certificate.</param>
         /// <param name="certificateStoreName">The certificate store name.</param>
         /// <param name="appId">The application identifier.</param>
-        /// <param name="options">The binding options.</param>
-        public HostnamePortBinding(HostnamePortKey key, string certificateThumbprint, string certificateStoreName, Guid appId, BindingOptions options = null)
+        /// <param name="options">The binding options, or <c>null</c> to use default options.</param>
+        public HostnamePortBinding(HostnamePortKey key, string certificateThumbprint, string certificateStoreName, Guid appId, BindingOptions? options = null)
             : this(key, new(certificateThumbprint, certificateStoreName), appId, options)
         {
         }
@@ -26,8 +26,8 @@ namespace SslCertBinding.Net
         /// <param name="key">The hostname binding key.</param>
         /// <param name="certificate">The bound certificate.</param>
         /// <param name="appId">The application identifier.</param>
-        /// <param name="options">The binding options.</param>
-        public HostnamePortBinding(HostnamePortKey key, SslCertificateReference certificate, Guid appId, BindingOptions options = null)
+        /// <param name="options">The binding options, or <c>null</c> to use default options.</param>
+        public HostnamePortBinding(HostnamePortKey key, SslCertificateReference certificate, Guid appId, BindingOptions? options = null)
             : base(appId, options)
         {
             Key = key ?? throw new ArgumentNullException(nameof(key));

--- a/src/SslCertBinding.Net/Bindings/IpPortBinding.cs
+++ b/src/SslCertBinding.Net/Bindings/IpPortBinding.cs
@@ -14,8 +14,8 @@ namespace SslCertBinding.Net
         /// <param name="certificateThumbprint">The thumbprint of the bound certificate.</param>
         /// <param name="certificateStoreName">The certificate store name.</param>
         /// <param name="appId">The application identifier.</param>
-        /// <param name="options">The binding options.</param>
-        public IpPortBinding(IpPortKey key, string certificateThumbprint, string certificateStoreName, Guid appId, BindingOptions options = null)
+        /// <param name="options">The binding options, or <c>null</c> to use default options.</param>
+        public IpPortBinding(IpPortKey key, string certificateThumbprint, string certificateStoreName, Guid appId, BindingOptions? options = null)
             : this(key, new(certificateThumbprint, certificateStoreName), appId, options)
         {
         }
@@ -26,8 +26,8 @@ namespace SslCertBinding.Net
         /// <param name="key">The IP binding key.</param>
         /// <param name="certificate">The bound certificate.</param>
         /// <param name="appId">The application identifier.</param>
-        /// <param name="options">The binding options.</param>
-        public IpPortBinding(IpPortKey key, SslCertificateReference certificate, Guid appId, BindingOptions options = null)
+        /// <param name="options">The binding options, or <c>null</c> to use default options.</param>
+        public IpPortBinding(IpPortKey key, SslCertificateReference certificate, Guid appId, BindingOptions? options = null)
             : base(appId, options)
         {
             Key = key ?? throw new ArgumentNullException(nameof(key));

--- a/src/SslCertBinding.Net/Bindings/ScopedCcsBinding.cs
+++ b/src/SslCertBinding.Net/Bindings/ScopedCcsBinding.cs
@@ -13,7 +13,7 @@ namespace SslCertBinding.Net
         /// <param name="key">The scoped CCS binding key.</param>
         /// <param name="appId">The application identifier.</param>
         /// <param name="options">The binding options.</param>
-        public ScopedCcsBinding(ScopedCcsKey key, Guid appId, BindingOptions options = null)
+        public ScopedCcsBinding(ScopedCcsKey key, Guid appId, BindingOptions? options = null)
             : base(appId, options)
         {
             Key = key ?? throw new ArgumentNullException(nameof(key));

--- a/src/SslCertBinding.Net/Compatibility/CertificateBinding.cs
+++ b/src/SslCertBinding.Net/Compatibility/CertificateBinding.cs
@@ -17,7 +17,7 @@ namespace SslCertBinding.Net
     public class CertificateBinding
     {
         /// <inheritdoc cref="CertificateBinding.CertificateBinding(string, string, System.Net.IPEndPoint, System.Guid, BindingOptions)" />
-        public CertificateBinding(string certificateThumbprint, StoreName certificateStoreName, IPEndPoint ipPort, Guid appId, BindingOptions options = null)
+        public CertificateBinding(string certificateThumbprint, StoreName certificateStoreName, IPEndPoint ipPort, Guid appId, BindingOptions? options = null)
             : this(certificateThumbprint, certificateStoreName.ToString(), ipPort, appId, options)
         {
         }
@@ -32,7 +32,7 @@ namespace SslCertBinding.Net
         /// <param name="options">Additional binding options.</param>
         /// <exception cref="ArgumentException">Thrown when <paramref name="certificateThumbprint"/> is null or empty.</exception>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="ipPort"/> is <c>null</c>.</exception>
-        public CertificateBinding(string certificateThumbprint, string certificateStoreName, IPEndPoint ipPort, Guid appId, BindingOptions options = null)
+        public CertificateBinding(string certificateThumbprint, string? certificateStoreName, IPEndPoint ipPort, Guid appId, BindingOptions? options = null)
         {
             if (string.IsNullOrEmpty(certificateThumbprint))
             {
@@ -93,7 +93,7 @@ namespace SslCertBinding.Net
                 CloneOptions(Options));
         }
 
-        internal static BindingOptions CloneOptions(BindingOptions options) =>
+        internal static BindingOptions CloneOptions(BindingOptions? options) =>
             options == null
                 ? new()
                 : new()

--- a/src/SslCertBinding.Net/Compatibility/CertificateBindingConfiguration.cs
+++ b/src/SslCertBinding.Net/Compatibility/CertificateBindingConfiguration.cs
@@ -33,7 +33,7 @@ namespace SslCertBinding.Net
         }
 
         /// <inheritdoc />
-        public IReadOnlyList<CertificateBinding> Query(IPEndPoint ipPort = null)
+        public IReadOnlyList<CertificateBinding> Query(IPEndPoint? ipPort = null)
         {
             IReadOnlyList<IpPortBinding> bindings;
             if (ipPort == null)
@@ -42,7 +42,7 @@ namespace SslCertBinding.Net
             }
             else
             {
-                IpPortBinding binding = _configuration.Find(new IpPortKey(ipPort));
+                IpPortBinding? binding = _configuration.Find(new IpPortKey(ipPort));
                 bindings = binding == null ? Array.Empty<IpPortBinding>() : new[] { binding };
             }
 

--- a/src/SslCertBinding.Net/Compatibility/CertificateBindingConfiguration.cs
+++ b/src/SslCertBinding.Net/Compatibility/CertificateBindingConfiguration.cs
@@ -35,9 +35,16 @@ namespace SslCertBinding.Net
         /// <inheritdoc />
         public IReadOnlyList<CertificateBinding> Query(IPEndPoint ipPort = null)
         {
-            IReadOnlyList<IpPortBinding> bindings = ipPort == null
-                ? _configuration.Query<IpPortBinding>()
-                : _configuration.Query(new IpPortKey(ipPort));
+            IReadOnlyList<IpPortBinding> bindings;
+            if (ipPort == null)
+            {
+                bindings = _configuration.Query<IpPortBinding>();
+            }
+            else
+            {
+                IpPortBinding binding = _configuration.Find(new IpPortKey(ipPort));
+                bindings = binding == null ? Array.Empty<IpPortBinding>() : new[] { binding };
+            }
 
             return [.. bindings.Select(CertificateBinding.From)];
         }

--- a/src/SslCertBinding.Net/Compatibility/ICertificateBindingConfiguration.cs
+++ b/src/SslCertBinding.Net/Compatibility/ICertificateBindingConfiguration.cs
@@ -22,7 +22,7 @@ namespace SslCertBinding.Net
         /// <returns>A list of <see cref="CertificateBinding"/> objects.</returns>
         /// <exception cref="PlatformNotSupportedException">Thrown when the Windows HTTP Server API is unavailable on the current platform.</exception>
         /// <exception cref="System.ComponentModel.Win32Exception">Thrown when the underlying HTTP Server API query fails.</exception>
-        IReadOnlyList<CertificateBinding> Query(IPEndPoint ipPort = null);
+        IReadOnlyList<CertificateBinding> Query(IPEndPoint? ipPort = null);
 
         /// <summary>
         /// Adds or updates an SSL certificate binding.

--- a/src/SslCertBinding.Net/ISslBindingConfiguration.cs
+++ b/src/SslCertBinding.Net/ISslBindingConfiguration.cs
@@ -28,35 +28,55 @@ namespace SslCertBinding.Net
         IReadOnlyList<TBinding> Query<TBinding>() where TBinding : ISslBinding;
 
         /// <summary>
-        /// Queries an exact IP-based SSL binding.
+        /// Finds an exact IP-based SSL binding.
         /// </summary>
-        /// <param name="key">The IP binding key to query.</param>
-        /// <returns>The matching IP bindings.</returns>
+        /// <param name="key">The IP binding key to find.</param>
+        /// <returns>The matching IP binding, or <c>null</c> when no binding exists for the specified key.</returns>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="key"/> is <c>null</c>.</exception>
         /// <exception cref="PlatformNotSupportedException">Thrown when the Windows HTTP Server API is unavailable on the current platform.</exception>
         /// <exception cref="Win32Exception">Thrown when the underlying HTTP Server API query fails.</exception>
-        IReadOnlyList<IpPortBinding> Query(IpPortKey key);
+        IpPortBinding Find(IpPortKey key);
 
         /// <summary>
-        /// Queries an exact hostname-based SSL binding.
+        /// Finds an exact hostname-based SSL binding.
         /// </summary>
-        /// <param name="key">The hostname binding key to query.</param>
-        /// <returns>The matching hostname bindings.</returns>
+        /// <param name="key">The hostname binding key to find.</param>
+        /// <returns>The matching hostname binding, or <c>null</c> when no binding exists for the specified key.</returns>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="key"/> is <c>null</c>.</exception>
         /// <exception cref="PlatformNotSupportedException">Thrown when the Windows HTTP Server API is unavailable on the current platform or when the current Windows version does not support hostname bindings (SNI).</exception>
         /// <exception cref="Win32Exception">Thrown when the underlying HTTP Server API query fails.</exception>
-        IReadOnlyList<HostnamePortBinding> Query(HostnamePortKey key);
+        HostnamePortBinding Find(HostnamePortKey key);
 
         /// <summary>
-        /// Queries an exact SSL binding using a runtime-selected binding key.
+        /// Finds an exact central certificate store SSL binding.
         /// </summary>
-        /// <param name="key">The binding key to query.</param>
-        /// <returns>The matching bindings.</returns>
+        /// <param name="key">The central certificate store binding key to find.</param>
+        /// <returns>The matching central certificate store binding, or <c>null</c> when no binding exists for the specified key.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="key"/> is <c>null</c>.</exception>
+        /// <exception cref="PlatformNotSupportedException">Thrown when the Windows HTTP Server API is unavailable on the current platform or when the current Windows version does not support central certificate store bindings.</exception>
+        /// <exception cref="Win32Exception">Thrown when the underlying HTTP Server API query fails.</exception>
+        CcsPortBinding Find(CcsPortKey key);
+
+        /// <summary>
+        /// Finds an exact scoped central certificate store SSL binding.
+        /// </summary>
+        /// <param name="key">The scoped central certificate store binding key to find.</param>
+        /// <returns>The matching scoped central certificate store binding, or <c>null</c> when no binding exists for the specified key.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="key"/> is <c>null</c>.</exception>
+        /// <exception cref="PlatformNotSupportedException">Thrown when the Windows HTTP Server API is unavailable on the current platform or when the current Windows version does not support scoped central certificate store bindings.</exception>
+        /// <exception cref="Win32Exception">Thrown when the underlying HTTP Server API query fails.</exception>
+        ScopedCcsBinding Find(ScopedCcsKey key);
+
+        /// <summary>
+        /// Finds an exact SSL binding using a runtime-selected binding key.
+        /// </summary>
+        /// <param name="key">The binding key to find.</param>
+        /// <returns>The matching binding, or <c>null</c> when no binding exists for the specified key.</returns>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="key"/> is <c>null</c>.</exception>
         /// <exception cref="NotSupportedException">Thrown when <paramref name="key"/> is not a supported binding key type.</exception>
         /// <exception cref="PlatformNotSupportedException">Thrown when the Windows HTTP Server API is unavailable on the current platform or when the selected binding family is not supported on the current Windows version.</exception>
         /// <exception cref="Win32Exception">Thrown when the underlying HTTP Server API query fails.</exception>
-        IReadOnlyList<ISslBinding> Query(SslBindingKey key);
+        ISslBinding Find(SslBindingKey key);
 
         /// <summary>
         /// Adds or updates an SSL binding.

--- a/src/SslCertBinding.Net/ISslBindingConfiguration.cs
+++ b/src/SslCertBinding.Net/ISslBindingConfiguration.cs
@@ -35,7 +35,7 @@ namespace SslCertBinding.Net
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="key"/> is <c>null</c>.</exception>
         /// <exception cref="PlatformNotSupportedException">Thrown when the Windows HTTP Server API is unavailable on the current platform.</exception>
         /// <exception cref="Win32Exception">Thrown when the underlying HTTP Server API query fails.</exception>
-        IpPortBinding Find(IpPortKey key);
+        IpPortBinding? Find(IpPortKey key);
 
         /// <summary>
         /// Finds an exact hostname-based SSL binding.
@@ -45,7 +45,7 @@ namespace SslCertBinding.Net
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="key"/> is <c>null</c>.</exception>
         /// <exception cref="PlatformNotSupportedException">Thrown when the Windows HTTP Server API is unavailable on the current platform or when the current Windows version does not support hostname bindings (SNI).</exception>
         /// <exception cref="Win32Exception">Thrown when the underlying HTTP Server API query fails.</exception>
-        HostnamePortBinding Find(HostnamePortKey key);
+        HostnamePortBinding? Find(HostnamePortKey key);
 
         /// <summary>
         /// Finds an exact central certificate store SSL binding.
@@ -55,7 +55,7 @@ namespace SslCertBinding.Net
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="key"/> is <c>null</c>.</exception>
         /// <exception cref="PlatformNotSupportedException">Thrown when the Windows HTTP Server API is unavailable on the current platform or when the current Windows version does not support central certificate store bindings.</exception>
         /// <exception cref="Win32Exception">Thrown when the underlying HTTP Server API query fails.</exception>
-        CcsPortBinding Find(CcsPortKey key);
+        CcsPortBinding? Find(CcsPortKey key);
 
         /// <summary>
         /// Finds an exact scoped central certificate store SSL binding.
@@ -65,7 +65,7 @@ namespace SslCertBinding.Net
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="key"/> is <c>null</c>.</exception>
         /// <exception cref="PlatformNotSupportedException">Thrown when the Windows HTTP Server API is unavailable on the current platform or when the current Windows version does not support scoped central certificate store bindings.</exception>
         /// <exception cref="Win32Exception">Thrown when the underlying HTTP Server API query fails.</exception>
-        ScopedCcsBinding Find(ScopedCcsKey key);
+        ScopedCcsBinding? Find(ScopedCcsKey key);
 
         /// <summary>
         /// Finds an exact SSL binding using a runtime-selected binding key.
@@ -76,7 +76,7 @@ namespace SslCertBinding.Net
         /// <exception cref="NotSupportedException">Thrown when <paramref name="key"/> is not a supported binding key type.</exception>
         /// <exception cref="PlatformNotSupportedException">Thrown when the Windows HTTP Server API is unavailable on the current platform or when the selected binding family is not supported on the current Windows version.</exception>
         /// <exception cref="Win32Exception">Thrown when the underlying HTTP Server API query fails.</exception>
-        ISslBinding Find(SslBindingKey key);
+        ISslBinding? Find(SslBindingKey key);
 
         /// <summary>
         /// Adds or updates an SSL binding.

--- a/src/SslCertBinding.Net/Internal/BindingKeyParser.cs
+++ b/src/SslCertBinding.Net/Internal/BindingKeyParser.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Net;
 
@@ -12,7 +13,7 @@ namespace SslCertBinding.Net.Internal
             return port >= IPEndPoint.MinPort && port <= IPEndPoint.MaxPort;
         }
 
-        public static bool TryParseIpPort(string value, out IPAddress address, out int port)
+        public static bool TryParseIpPort(string? value, [NotNullWhen(true)] out IPAddress? address, out int port)
         {
             address = null;
             port = 0;
@@ -22,7 +23,7 @@ namespace SslCertBinding.Net.Internal
                 return false;
             }
 
-            value = value.Trim();
+            value = value!.Trim();
             string hostPart;
             string portPart;
             if (value[0] == '[')
@@ -56,7 +57,7 @@ namespace SslCertBinding.Net.Internal
             return IPAddress.TryParse(hostPart, out address);
         }
 
-        public static bool TryParseHostPort(string value, out string host, out int port)
+        public static bool TryParseHostPort(string? value, [NotNullWhen(true)] out string? host, out int port)
         {
             host = null;
             port = 0;
@@ -66,7 +67,7 @@ namespace SslCertBinding.Net.Internal
                 return false;
             }
 
-            value = value.Trim();
+            value = value!.Trim();
             int separatorIndex = value.LastIndexOf(':');
             if (separatorIndex <= 0 || separatorIndex == value.Length - 1)
             {
@@ -90,44 +91,45 @@ namespace SslCertBinding.Net.Internal
             return true;
         }
 
-        public static bool TryParsePort(string value, out int port)
+        public static bool TryParsePort(string? value, out int port)
         {
             return int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out port)
                 && IsValidPort(port);
         }
 
-        public static bool IsValidHostname(string host)
+        public static bool IsValidHostname(string? host)
         {
             if (string.IsNullOrWhiteSpace(host))
             {
                 return false;
             }
 
-            if (!string.Equals(host, host.Trim(), StringComparison.Ordinal)
-                || host.IndexOf(':') >= 0
-                || IPAddress.TryParse(host, out _))
+            string nonNullHost = host!;
+            if (!string.Equals(nonNullHost, nonNullHost.Trim(), StringComparison.Ordinal)
+                || nonNullHost.IndexOf(':') >= 0
+                || IPAddress.TryParse(nonNullHost, out _))
             {
                 return false;
             }
 
-            int wildcardIndex = host.IndexOf('*');
+            int wildcardIndex = nonNullHost.IndexOf('*');
             if (wildcardIndex >= 0)
             {
-                if (!host.StartsWith("*.", StringComparison.Ordinal) || wildcardIndex != 0)
+                if (!nonNullHost.StartsWith("*.", StringComparison.Ordinal) || wildcardIndex != 0)
                 {
                     return false;
                 }
 
-                string wildcardSuffix = host.Substring(2);
+                string wildcardSuffix = nonNullHost.Substring(2);
                 return wildcardSuffix.Length > 0
                     && wildcardSuffix.IndexOf('*') < 0
                     && Uri.CheckHostName(wildcardSuffix) == UriHostNameType.Dns;
             }
 
-            return Uri.CheckHostName(host) == UriHostNameType.Dns;
+            return Uri.CheckHostName(nonNullHost) == UriHostNameType.Dns;
         }
 
-        public static string RequireValidHostname(string host, string paramName)
+        public static string RequireValidHostname(string? host, string paramName)
         {
             if (!IsValidHostname(host))
             {
@@ -136,7 +138,7 @@ namespace SslCertBinding.Net.Internal
                     paramName);
             }
 
-            return host;
+            return host!;
         }
     }
 #pragma warning restore CA2249 // IndexOf is used for .NET Framework compatibility.

--- a/src/SslCertBinding.Net/Internal/Configuration/BindingFamilyInterop.cs
+++ b/src/SslCertBinding.Net/Internal/Configuration/BindingFamilyInterop.cs
@@ -83,7 +83,7 @@ namespace SslCertBinding.Net.Internal
             }
         }
 
-        public static TBinding QuerySingle<TQuery, TSet, TBinding>(
+        public static TBinding? QuerySingle<TQuery, TSet, TBinding>(
             HttpApi.HTTP_SERVICE_CONFIG_ID configId,
             SafeInteropResult<TQuery> queryStruct,
             Func<TSet, TBinding> mapFunc)
@@ -91,7 +91,7 @@ namespace SslCertBinding.Net.Internal
             where TSet : struct
             where TBinding : class
         {
-            TBinding result = null;
+            TBinding? result = null;
 
             try
             {

--- a/src/SslCertBinding.Net/Internal/Configuration/BindingFamilyOperations.cs
+++ b/src/SslCertBinding.Net/Internal/Configuration/BindingFamilyOperations.cs
@@ -22,7 +22,7 @@ namespace SslCertBinding.Net.Internal
 
         IReadOnlyList<ISslBinding> QueryAll();
 
-        ISslBinding FindExact(SslBindingKey key);
+        ISslBinding? FindExact(SslBindingKey key);
 
         void Upsert(ISslBinding binding);
 
@@ -64,9 +64,9 @@ namespace SslCertBinding.Net.Internal
 
         public IReadOnlyList<ISslBinding> QueryAll() => QueryAllCore().Cast<ISslBinding>().ToArray();
 
-        public ISslBinding FindExact(SslBindingKey key)
+        public ISslBinding? FindExact(SslBindingKey key)
         {
-            TBinding binding = QueryExactCore((TKey)key);
+            TBinding? binding = QueryExactCore((TKey)key);
             return binding;
         }
 
@@ -78,7 +78,7 @@ namespace SslCertBinding.Net.Internal
 
         protected abstract IReadOnlyList<TBinding> QueryAllCore();
 
-        protected abstract TBinding QueryExactCore(TKey key);
+        protected abstract TBinding? QueryExactCore(TKey key);
 
         protected virtual void UpsertCore(TBinding binding)
         {
@@ -111,7 +111,7 @@ namespace SslCertBinding.Net.Internal
                 BindingStructures.CreateNextIpQuery,
                 BindingStructures.MapIpBinding);
 
-        protected override IpPortBinding QueryExactCore(IpPortKey key) =>
+        protected override IpPortBinding? QueryExactCore(IpPortKey key) =>
             BindingFamilyInterop.QuerySingle<HttpApi.HTTP_SERVICE_CONFIG_SSL_QUERY, HttpApi.HTTP_SERVICE_CONFIG_SSL_SET, IpPortBinding>(
                 ConfigId,
                 BindingStructures.CreateExactQuery(key),
@@ -149,7 +149,7 @@ namespace SslCertBinding.Net.Internal
                 BindingStructures.CreateNextHostnameQuery,
                 BindingStructures.MapHostnameBinding);
 
-        protected override HostnamePortBinding QueryExactCore(HostnamePortKey key) =>
+        protected override HostnamePortBinding? QueryExactCore(HostnamePortKey key) =>
             BindingFamilyInterop.QuerySingle<HttpApi.HTTP_SERVICE_CONFIG_SSL_SNI_QUERY, HttpApi.HTTP_SERVICE_CONFIG_SSL_SNI_SET, HostnamePortBinding>(
                 ConfigId,
                 BindingStructures.CreateExactQuery(key),
@@ -187,7 +187,7 @@ namespace SslCertBinding.Net.Internal
                 BindingStructures.CreateNextCcsQuery,
                 BindingStructures.MapCcsBinding);
 
-        protected override CcsPortBinding QueryExactCore(CcsPortKey key) =>
+        protected override CcsPortBinding? QueryExactCore(CcsPortKey key) =>
             BindingFamilyInterop.QuerySingle<HttpApi.HTTP_SERVICE_CONFIG_SSL_CCS_QUERY, HttpApi.HTTP_SERVICE_CONFIG_SSL_CCS_SET, CcsPortBinding>(
                 ConfigId,
                 BindingStructures.CreateExactQuery(key),
@@ -231,7 +231,7 @@ namespace SslCertBinding.Net.Internal
                 BindingStructures.CreateNextScopedCcsQuery,
                 BindingStructures.MapScopedCcsBinding);
 
-        protected override ScopedCcsBinding QueryExactCore(ScopedCcsKey key) =>
+        protected override ScopedCcsBinding? QueryExactCore(ScopedCcsKey key) =>
             BindingFamilyInterop.QuerySingle<HttpApi.HTTP_SERVICE_CONFIG_SSL_SNI_QUERY, HttpApi.HTTP_SERVICE_CONFIG_SSL_SNI_SET, ScopedCcsBinding>(
                 ConfigId,
                 BindingStructures.CreateExactQuery(key),

--- a/src/SslCertBinding.Net/Internal/Configuration/BindingFamilyOperations.cs
+++ b/src/SslCertBinding.Net/Internal/Configuration/BindingFamilyOperations.cs
@@ -22,7 +22,7 @@ namespace SslCertBinding.Net.Internal
 
         IReadOnlyList<ISslBinding> QueryAll();
 
-        IReadOnlyList<ISslBinding> QueryExact(SslBindingKey key);
+        ISslBinding FindExact(SslBindingKey key);
 
         void Upsert(ISslBinding binding);
 
@@ -64,10 +64,10 @@ namespace SslCertBinding.Net.Internal
 
         public IReadOnlyList<ISslBinding> QueryAll() => QueryAllCore().Cast<ISslBinding>().ToArray();
 
-        public IReadOnlyList<ISslBinding> QueryExact(SslBindingKey key)
+        public ISslBinding FindExact(SslBindingKey key)
         {
             TBinding binding = QueryExactCore((TKey)key);
-            return binding == null ? Array.Empty<ISslBinding>() : new ISslBinding[] { binding };
+            return binding;
         }
 
         public void Upsert(ISslBinding binding) => UpsertCore((TBinding)binding);

--- a/src/SslCertBinding.Net/Internal/Interop/BindingStructures.cs
+++ b/src/SslCertBinding.Net/Internal/Interop/BindingStructures.cs
@@ -203,7 +203,7 @@ namespace SslCertBinding.Net.Internal.Interop
 
             return new(
                 new(SockaddrInterop.ReadSockaddrStructPtr(bindingStruct.KeyDesc.pIpPort)),
-                new(GetThumbprint(hashBytes), bindingStruct.ParamDesc.pSslCertStoreName),
+                CreateCertificateReference(GetThumbprint(hashBytes), bindingStruct.ParamDesc.pSslCertStoreName),
                 bindingStruct.ParamDesc.AppId,
                 CreateBindingOptions(bindingStruct.ParamDesc));
         }
@@ -215,8 +215,8 @@ namespace SslCertBinding.Net.Internal.Interop
 
             IPEndPoint ipPort = SockaddrInterop.CreateIPEndPoint(bindingStruct.KeyDesc.IpPort);
             return new(
-                new(bindingStruct.KeyDesc.Host, ipPort.Port),
-                new(GetThumbprint(hashBytes), bindingStruct.ParamDesc.pSslCertStoreName),
+                new(bindingStruct.KeyDesc.Host!, ipPort.Port),
+                CreateCertificateReference(GetThumbprint(hashBytes), bindingStruct.ParamDesc.pSslCertStoreName),
                 bindingStruct.ParamDesc.AppId,
                 CreateBindingOptions(bindingStruct.ParamDesc));
         }
@@ -234,7 +234,7 @@ namespace SslCertBinding.Net.Internal.Interop
         {
             IPEndPoint ipPort = SockaddrInterop.CreateIPEndPoint(bindingStruct.KeyDesc.IpPort);
             return new(
-                new(bindingStruct.KeyDesc.Host, ipPort.Port),
+                new(bindingStruct.KeyDesc.Host!, ipPort.Port),
                 bindingStruct.ParamDesc.AppId,
                 CreateBindingOptions(bindingStruct.ParamDesc));
         }
@@ -329,6 +329,13 @@ namespace SslCertBinding.Net.Internal.Interop
 
             return bytes;
         }
+
+        private static SslCertificateReference CreateCertificateReference(string thumbprint, string? storeName) =>
+            // HTTP.sys may omit the store name on query results for bindings that still
+            // logically live in the default MY store, so we normalize that readback here.
+            string.IsNullOrEmpty(storeName)
+                ? new SslCertificateReference(thumbprint)
+                : new SslCertificateReference(thumbprint, storeName!);
 
         private static string GetThumbprint(byte[] hash)
         {

--- a/src/SslCertBinding.Net/Internal/Interop/HttpApi.cs
+++ b/src/SslCertBinding.Net/Internal/Interop/HttpApi.cs
@@ -157,7 +157,7 @@ namespace SslCertBinding.Net.Internal.Interop
             public SOCKADDR_STORAGE IpPort;
 
             [MarshalAs(UnmanagedType.LPWStr)]
-            public string Host;
+            public string? Host;
         }
 
         [StructLayout(LayoutKind.Sequential)]
@@ -176,17 +176,17 @@ namespace SslCertBinding.Net.Internal.Interop
             public Guid AppId;
 
             [MarshalAs(UnmanagedType.LPWStr)]
-            public string pSslCertStoreName;
+            public string? pSslCertStoreName;
 
             public CertCheckModes DefaultCertCheckMode;
             public int DefaultRevocationFreshnessTime;
             public int DefaultRevocationUrlRetrievalTimeout;
 
             [MarshalAs(UnmanagedType.LPWStr)]
-            public string pDefaultSslCtlIdentifier;
+            public string? pDefaultSslCtlIdentifier;
 
             [MarshalAs(UnmanagedType.LPWStr)]
-            public string pDefaultSslCtlStoreName;
+            public string? pDefaultSslCtlStoreName;
 
             public HTTP_SERVICE_CONFIG_SSL_FLAG DefaultFlags;
         }

--- a/src/SslCertBinding.Net/Internal/NullableAttributes.cs
+++ b/src/SslCertBinding.Net/Internal/NullableAttributes.cs
@@ -1,0 +1,15 @@
+#if NET462
+namespace System.Diagnostics.CodeAnalysis
+{
+    [AttributeUsage(AttributeTargets.Parameter)]
+    internal sealed class NotNullWhenAttribute : Attribute
+    {
+        public NotNullWhenAttribute(bool returnValue)
+        {
+            ReturnValue = returnValue;
+        }
+
+        public bool ReturnValue { get; }
+    }
+}
+#endif

--- a/src/SslCertBinding.Net/Internal/PlatformHelpers.cs
+++ b/src/SslCertBinding.Net/Internal/PlatformHelpers.cs
@@ -16,7 +16,7 @@ namespace SslCertBinding.Net.Internal
 #endif
         }
 
-        public static PlatformNotSupportedException CreateWindowsOnlyException(Exception innerException = null)
+        public static PlatformNotSupportedException CreateWindowsOnlyException(Exception? innerException = null)
             => new PlatformNotSupportedException(WindowsOnlyMessage, innerException);
     }
 }

--- a/src/SslCertBinding.Net/Keys/CcsPortKey.cs
+++ b/src/SslCertBinding.Net/Keys/CcsPortKey.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using SslCertBinding.Net.Internal;
 
@@ -47,7 +48,7 @@ namespace SslCertBinding.Net
         /// <param name="value">The textual representation of the key.</param>
         /// <param name="key">When this method returns, contains the parsed key if parsing succeeded.</param>
         /// <returns><c>true</c> if parsing succeeded; otherwise <c>false</c>.</returns>
-        public static bool TryParse(string value, out CcsPortKey key)
+        public static bool TryParse(string? value, [NotNullWhen(true)] out CcsPortKey? key)
         {
             key = null;
             if (!BindingKeyParser.TryParsePort(value, out int port))
@@ -68,7 +69,7 @@ namespace SslCertBinding.Net
         /// <exception cref="FormatException">Thrown when <paramref name="value"/> is not a valid CCS binding key.</exception>
         public static CcsPortKey Parse(string value)
         {
-            if (!TryParse(value ?? throw new ArgumentNullException(nameof(value)), out CcsPortKey key))
+            if (!TryParse(value ?? throw new ArgumentNullException(nameof(value)), out CcsPortKey? key))
             {
                 throw new FormatException(FormatErrorMessage);
             }
@@ -80,12 +81,12 @@ namespace SslCertBinding.Net
         public override string ToString() => Port.ToString(CultureInfo.InvariantCulture);
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => obj is CcsPortKey key && Equals(key);
+        public override bool Equals(object? obj) => obj is CcsPortKey key && Equals(key);
 
         /// <inheritdoc />
         public override int GetHashCode() => Port.GetHashCode();
 
         /// <inheritdoc />
-        public bool Equals(CcsPortKey other) => other != null && Port == other.Port;
+        public bool Equals(CcsPortKey? other) => other != null && Port == other.Port;
     }
 }

--- a/src/SslCertBinding.Net/Keys/HostnamePortKey.cs
+++ b/src/SslCertBinding.Net/Keys/HostnamePortKey.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Net;
 using SslCertBinding.Net.Internal;
@@ -70,10 +71,10 @@ namespace SslCertBinding.Net
         /// <param name="value">The textual representation of the key.</param>
         /// <param name="key">When this method returns, contains the parsed key if parsing succeeded.</param>
         /// <returns><c>true</c> if parsing succeeded; otherwise <c>false</c>.</returns>
-        public static bool TryParse(string value, out HostnamePortKey key)
+        public static bool TryParse(string? value, [NotNullWhen(true)] out HostnamePortKey? key)
         {
             key = null;
-            if (!BindingKeyParser.TryParseHostPort(value, out string host, out int port))
+            if (!BindingKeyParser.TryParseHostPort(value, out string? host, out int port))
             {
                 return false;
             }
@@ -91,7 +92,7 @@ namespace SslCertBinding.Net
         /// <exception cref="FormatException">Thrown when <paramref name="value"/> is not a valid hostname binding key.</exception>
         public static HostnamePortKey Parse(string value)
         {
-            if (!TryParse(value ?? throw new ArgumentNullException(nameof(value)), out HostnamePortKey key))
+            if (!TryParse(value ?? throw new ArgumentNullException(nameof(value)), out HostnamePortKey? key))
             {
                 throw new FormatException(FormatErrorMessage);
             }
@@ -103,7 +104,7 @@ namespace SslCertBinding.Net
         public override string ToString() => string.Format(CultureInfo.InvariantCulture, "{0}:{1}", Hostname, Port);
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => obj switch
+        public override bool Equals(object? obj) => obj switch
         {
             DnsEndPoint endPoint => Equals(endPoint),
             HostnamePortKey key => Equals(key),
@@ -114,7 +115,7 @@ namespace SslCertBinding.Net
         public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Hostname) ^ Port.GetHashCode();
 
         /// <inheritdoc />
-        public bool Equals(HostnamePortKey other)
+        public bool Equals(HostnamePortKey? other)
         {
             return other != null
                 && StringComparer.OrdinalIgnoreCase.Equals(Hostname, other.Hostname)
@@ -122,7 +123,7 @@ namespace SslCertBinding.Net
         }
 
         /// <inheritdoc />
-        public bool Equals(DnsEndPoint other)
+        public bool Equals(DnsEndPoint? other)
         {
             return other != null
                 && StringComparer.OrdinalIgnoreCase.Equals(Hostname, other.Host)
@@ -133,12 +134,12 @@ namespace SslCertBinding.Net
         /// Converts a <see cref="DnsEndPoint"/> to a <see cref="HostnamePortKey"/>.
         /// </summary>
         /// <param name="endPoint">The endpoint to convert.</param>
-        public static implicit operator HostnamePortKey(DnsEndPoint endPoint) => From(endPoint);
+        public static implicit operator HostnamePortKey?(DnsEndPoint? endPoint) => endPoint == null ? null : From(endPoint);
 
         /// <summary>
         /// Converts a <see cref="HostnamePortKey"/> to a <see cref="DnsEndPoint"/>.
         /// </summary>
         /// <param name="key">The key to convert.</param>
-        public static implicit operator DnsEndPoint(HostnamePortKey key) => key?.ToDnsEndPoint();
+        public static implicit operator DnsEndPoint?(HostnamePortKey? key) => key?.ToDnsEndPoint();
     }
 }

--- a/src/SslCertBinding.Net/Keys/IpPortKey.cs
+++ b/src/SslCertBinding.Net/Keys/IpPortKey.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using SslCertBinding.Net.Internal;
 
@@ -67,10 +68,10 @@ namespace SslCertBinding.Net
         /// <param name="value">The textual representation of the key.</param>
         /// <param name="key">When this method returns, contains the parsed key if parsing succeeded.</param>
         /// <returns><c>true</c> if parsing succeeded; otherwise <c>false</c>.</returns>
-        public static bool TryParse(string value, out IpPortKey key)
+        public static bool TryParse(string? value, [NotNullWhen(true)] out IpPortKey? key)
         {
             key = null;
-            if (!BindingKeyParser.TryParseIpPort(value, out IPAddress address, out int port))
+            if (!BindingKeyParser.TryParseIpPort(value, out IPAddress? address, out int port))
             {
                 return false;
             }
@@ -88,7 +89,7 @@ namespace SslCertBinding.Net
         /// <exception cref="FormatException">Thrown when <paramref name="value"/> is not a valid IP binding key.</exception>
         public static IpPortKey Parse(string value)
         {
-            if (!TryParse(value ?? throw new ArgumentNullException(nameof(value)), out IpPortKey key))
+            if (!TryParse(value ?? throw new ArgumentNullException(nameof(value)), out IpPortKey? key))
             {
                 throw new FormatException(FormatErrorMessage);
             }
@@ -100,7 +101,7 @@ namespace SslCertBinding.Net
         public override string ToString() => ToIPEndPoint().ToString();
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => obj switch
+        public override bool Equals(object? obj) => obj switch
         {
             IPEndPoint endPoint => Equals(endPoint),
             IpPortKey key => Equals(key),
@@ -111,13 +112,13 @@ namespace SslCertBinding.Net
         public override int GetHashCode() => ToIPEndPoint().GetHashCode();
 
         /// <inheritdoc />
-        public bool Equals(IpPortKey other)
+        public bool Equals(IpPortKey? other)
         {
             return other != null && Address.Equals(other.Address) && Port == other.Port;
         }
 
         /// <inheritdoc />
-        public bool Equals(IPEndPoint other)
+        public bool Equals(IPEndPoint? other)
         {
             return other != null && ToIPEndPoint().Equals(other);
         }
@@ -126,12 +127,12 @@ namespace SslCertBinding.Net
         /// Converts an <see cref="IPEndPoint"/> to an <see cref="IpPortKey"/>.
         /// </summary>
         /// <param name="endPoint">The endpoint to convert.</param>
-        public static implicit operator IpPortKey(IPEndPoint endPoint) => From(endPoint);
+        public static implicit operator IpPortKey?(IPEndPoint? endPoint) => endPoint == null ? null : From(endPoint);
 
         /// <summary>
         /// Converts an <see cref="IpPortKey"/> to an <see cref="IPEndPoint"/>.
         /// </summary>
         /// <param name="key">The key to convert.</param>
-        public static implicit operator IPEndPoint(IpPortKey key) => key?.ToIPEndPoint();
+        public static implicit operator IPEndPoint?(IpPortKey? key) => key?.ToIPEndPoint();
     }
 }

--- a/src/SslCertBinding.Net/Keys/ScopedCcsKey.cs
+++ b/src/SslCertBinding.Net/Keys/ScopedCcsKey.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Net;
 using SslCertBinding.Net.Internal;
@@ -70,10 +71,10 @@ namespace SslCertBinding.Net
         /// <param name="value">The textual representation of the key.</param>
         /// <param name="key">When this method returns, contains the parsed key if parsing succeeded.</param>
         /// <returns><c>true</c> if parsing succeeded; otherwise <c>false</c>.</returns>
-        public static bool TryParse(string value, out ScopedCcsKey key)
+        public static bool TryParse(string? value, [NotNullWhen(true)] out ScopedCcsKey? key)
         {
             key = null;
-            if (!BindingKeyParser.TryParseHostPort(value, out string host, out int port))
+            if (!BindingKeyParser.TryParseHostPort(value, out string? host, out int port))
             {
                 return false;
             }
@@ -91,7 +92,7 @@ namespace SslCertBinding.Net
         /// <exception cref="FormatException">Thrown when <paramref name="value"/> is not a valid scoped CCS binding key.</exception>
         public static ScopedCcsKey Parse(string value)
         {
-            if (!TryParse(value ?? throw new ArgumentNullException(nameof(value)), out ScopedCcsKey key))
+            if (!TryParse(value ?? throw new ArgumentNullException(nameof(value)), out ScopedCcsKey? key))
             {
                 throw new FormatException(FormatErrorMessage);
             }
@@ -103,7 +104,7 @@ namespace SslCertBinding.Net
         public override string ToString() => string.Format(CultureInfo.InvariantCulture, "{0}:{1}", Hostname, Port);
 
         /// <inheritdoc />
-        public override bool Equals(object obj) => obj switch
+        public override bool Equals(object? obj) => obj switch
         {
             DnsEndPoint endPoint => Equals(endPoint),
             ScopedCcsKey key => Equals(key),
@@ -114,7 +115,7 @@ namespace SslCertBinding.Net
         public override int GetHashCode() => StringComparer.OrdinalIgnoreCase.GetHashCode(Hostname) ^ Port.GetHashCode();
 
         /// <inheritdoc />
-        public bool Equals(ScopedCcsKey other)
+        public bool Equals(ScopedCcsKey? other)
         {
             return other != null
                 && StringComparer.OrdinalIgnoreCase.Equals(Hostname, other.Hostname)
@@ -122,7 +123,7 @@ namespace SslCertBinding.Net
         }
 
         /// <inheritdoc />
-        public bool Equals(DnsEndPoint other)
+        public bool Equals(DnsEndPoint? other)
         {
             return other != null
                 && StringComparer.OrdinalIgnoreCase.Equals(Hostname, other.Host)
@@ -133,12 +134,12 @@ namespace SslCertBinding.Net
         /// Converts a <see cref="DnsEndPoint"/> to a <see cref="ScopedCcsKey"/>.
         /// </summary>
         /// <param name="endPoint">The endpoint to convert.</param>
-        public static implicit operator ScopedCcsKey(DnsEndPoint endPoint) => From(endPoint);
+        public static implicit operator ScopedCcsKey?(DnsEndPoint? endPoint) => endPoint == null ? null : From(endPoint);
 
         /// <summary>
         /// Converts a <see cref="ScopedCcsKey"/> to a <see cref="DnsEndPoint"/>.
         /// </summary>
         /// <param name="key">The key to convert.</param>
-        public static implicit operator DnsEndPoint(ScopedCcsKey key) => key?.ToDnsEndPoint();
+        public static implicit operator DnsEndPoint?(ScopedCcsKey? key) => key?.ToDnsEndPoint();
     }
 }

--- a/src/SslCertBinding.Net/Keys/SslBindingKey.cs
+++ b/src/SslCertBinding.Net/Keys/SslBindingKey.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SslCertBinding.Net
 {
@@ -46,12 +47,12 @@ namespace SslCertBinding.Net
         /// <param name="key">When this method returns, contains the parsed key if parsing succeeded.</param>
         /// <returns><c>true</c> if parsing succeeded; otherwise <c>false</c>.</returns>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="kind"/> is not a supported binding family.</exception>
-        public static bool TryParse(string value, SslBindingKind kind, out SslBindingKey key)
+        public static bool TryParse(string? value, SslBindingKind kind, [NotNullWhen(true)] out SslBindingKey? key)
         {
             switch (kind)
             {
                 case SslBindingKind.IpPort:
-                    if (IpPortKey.TryParse(value, out IpPortKey ipKey))
+                    if (IpPortKey.TryParse(value, out IpPortKey? ipKey))
                     {
                         key = ipKey;
                         return true;
@@ -59,7 +60,7 @@ namespace SslCertBinding.Net
 
                     break;
                 case SslBindingKind.HostnamePort:
-                    if (HostnamePortKey.TryParse(value, out HostnamePortKey hostnameKey))
+                    if (HostnamePortKey.TryParse(value, out HostnamePortKey? hostnameKey))
                     {
                         key = hostnameKey;
                         return true;
@@ -67,7 +68,7 @@ namespace SslCertBinding.Net
 
                     break;
                 case SslBindingKind.CcsPort:
-                    if (CcsPortKey.TryParse(value, out CcsPortKey ccsKey))
+                    if (CcsPortKey.TryParse(value, out CcsPortKey? ccsKey))
                     {
                         key = ccsKey;
                         return true;
@@ -75,7 +76,7 @@ namespace SslCertBinding.Net
 
                     break;
                 case SslBindingKind.ScopedCcs:
-                    if (ScopedCcsKey.TryParse(value, out ScopedCcsKey scopedCcsKey))
+                    if (ScopedCcsKey.TryParse(value, out ScopedCcsKey? scopedCcsKey))
                     {
                         key = scopedCcsKey;
                         return true;

--- a/src/SslCertBinding.Net/Keys/SslBindingKeyExtensions.cs
+++ b/src/SslCertBinding.Net/Keys/SslBindingKeyExtensions.cs
@@ -15,7 +15,7 @@ namespace SslCertBinding.Net
         /// <returns>
         /// The converted key, or <c>null</c> when <paramref name="endPoint"/> is <c>null</c>.
         /// </returns>
-        public static IpPortKey ToSslBindingKey(this IPEndPoint endPoint) =>
+        public static IpPortKey? ToSslBindingKey(this IPEndPoint? endPoint) =>
             endPoint == null ? null : new IpPortKey(endPoint);
 
         /// <summary>
@@ -25,7 +25,7 @@ namespace SslCertBinding.Net
         /// <returns>
         /// The converted key, or <c>null</c> when <paramref name="endPoint"/> is <c>null</c>.
         /// </returns>
-        public static HostnamePortKey ToHostnamePortKey(this DnsEndPoint endPoint) =>
+        public static HostnamePortKey? ToHostnamePortKey(this DnsEndPoint? endPoint) =>
             endPoint == null ? null : new HostnamePortKey(endPoint);
 
         /// <summary>
@@ -35,7 +35,7 @@ namespace SslCertBinding.Net
         /// <returns>
         /// The converted key, or <c>null</c> when <paramref name="endPoint"/> is <c>null</c>.
         /// </returns>
-        public static ScopedCcsKey ToScopedCcsKey(this DnsEndPoint endPoint) =>
+        public static ScopedCcsKey? ToScopedCcsKey(this DnsEndPoint? endPoint) =>
             endPoint == null ? null : new ScopedCcsKey(endPoint);
     }
 }

--- a/src/SslCertBinding.Net/Keys/SslBindingKeyExtensions.cs
+++ b/src/SslCertBinding.Net/Keys/SslBindingKeyExtensions.cs
@@ -15,7 +15,7 @@ namespace SslCertBinding.Net
         /// <returns>
         /// The converted key, or <c>null</c> when <paramref name="endPoint"/> is <c>null</c>.
         /// </returns>
-        public static IpPortKey? ToSslBindingKey(this IPEndPoint? endPoint) =>
+        public static IpPortKey? ToIpPortKey(this IPEndPoint? endPoint) =>
             endPoint == null ? null : new IpPortKey(endPoint);
 
         /// <summary>

--- a/src/SslCertBinding.Net/SslBinding.cs
+++ b/src/SslCertBinding.Net/SslBinding.cs
@@ -14,7 +14,7 @@ namespace SslCertBinding.Net
         /// </summary>
         /// <param name="appId">The application identifier that owns the binding.</param>
         /// <param name="options">The binding options.</param>
-        protected SslBinding(Guid appId, BindingOptions options = null)
+        protected SslBinding(Guid appId, BindingOptions? options = null)
         {
             AppId = appId;
             Options = options ?? new();

--- a/src/SslCertBinding.Net/SslBindingConfiguration.cs
+++ b/src/SslCertBinding.Net/SslBindingConfiguration.cs
@@ -75,38 +75,38 @@ namespace SslCertBinding.Net
         }
 
         /// <inheritdoc />
-        public IpPortBinding Find(IpPortKey key)
+        public IpPortBinding? Find(IpPortKey key)
         {
             ThrowHelper.ThrowIfNull(key, nameof(key));
-            return (IpPortBinding)GetSupportedBindingOperations(key).FindExact(key);
+            return (IpPortBinding?)GetSupportedBindingOperations(key).FindExact(key);
         }
 
         /// <inheritdoc />
-        public HostnamePortBinding Find(HostnamePortKey key)
-        {
-            ThrowHelper.ThrowIfNull(key, nameof(key));
-            ISslBindingFamilyOperations operations = GetSupportedBindingOperations(key);
-            return (HostnamePortBinding)operations.FindExact(key);
-        }
-
-        /// <inheritdoc />
-        public CcsPortBinding Find(CcsPortKey key)
+        public HostnamePortBinding? Find(HostnamePortKey key)
         {
             ThrowHelper.ThrowIfNull(key, nameof(key));
             ISslBindingFamilyOperations operations = GetSupportedBindingOperations(key);
-            return (CcsPortBinding)operations.FindExact(key);
+            return (HostnamePortBinding?)operations.FindExact(key);
         }
 
         /// <inheritdoc />
-        public ScopedCcsBinding Find(ScopedCcsKey key)
+        public CcsPortBinding? Find(CcsPortKey key)
         {
             ThrowHelper.ThrowIfNull(key, nameof(key));
             ISslBindingFamilyOperations operations = GetSupportedBindingOperations(key);
-            return (ScopedCcsBinding)operations.FindExact(key);
+            return (CcsPortBinding?)operations.FindExact(key);
         }
 
         /// <inheritdoc />
-        public ISslBinding Find(SslBindingKey key)
+        public ScopedCcsBinding? Find(ScopedCcsKey key)
+        {
+            ThrowHelper.ThrowIfNull(key, nameof(key));
+            ISslBindingFamilyOperations operations = GetSupportedBindingOperations(key);
+            return (ScopedCcsBinding?)operations.FindExact(key);
+        }
+
+        /// <inheritdoc />
+        public ISslBinding? Find(SslBindingKey key)
         {
             ThrowHelper.ThrowIfNull(key, nameof(key));
             ISslBindingFamilyOperations operations = GetSupportedBindingOperations(key);
@@ -254,7 +254,7 @@ namespace SslCertBinding.Net
 
         private static ISslBindingFamilyOperations GetBindingOperations(SslBindingKind kind)
         {
-            if (BindingFamilyOperationsByKind.TryGetValue(kind, out ISslBindingFamilyOperations operations))
+            if (BindingFamilyOperationsByKind.TryGetValue(kind, out ISslBindingFamilyOperations? operations))
             {
                 return operations;
             }
@@ -263,7 +263,7 @@ namespace SslCertBinding.Net
         }
 
         private static ISslBindingFamilyOperations GetBindingOperations(SslBindingKey key) =>
-            BindingFamilyOperationsByKeyType.TryGetValue(key.GetType(), out ISslBindingFamilyOperations operations)
+            BindingFamilyOperationsByKeyType.TryGetValue(key.GetType(), out ISslBindingFamilyOperations? operations)
                 ? operations
                 : throw CreateNotSupportedException(key.GetType());
 
@@ -273,7 +273,7 @@ namespace SslCertBinding.Net
 
         private static ISslBindingFamilyOperations GetBindingOperationsForBindingType(Type type)
         {
-            if (BindingFamilyOperationsByBindingType.TryGetValue(type, out ISslBindingFamilyOperations operations))
+            if (BindingFamilyOperationsByBindingType.TryGetValue(type, out ISslBindingFamilyOperations? operations))
             {
                 return operations;
             }

--- a/src/SslCertBinding.Net/SslBindingConfiguration.cs
+++ b/src/SslCertBinding.Net/SslBindingConfiguration.cs
@@ -75,42 +75,42 @@ namespace SslCertBinding.Net
         }
 
         /// <inheritdoc />
-        public IReadOnlyList<IpPortBinding> Query(IpPortKey key)
+        public IpPortBinding Find(IpPortKey key)
         {
             ThrowHelper.ThrowIfNull(key, nameof(key));
-            return GetSupportedBindingOperations(key).QueryExact(key).Cast<IpPortBinding>().ToArray();
+            return (IpPortBinding)GetSupportedBindingOperations(key).FindExact(key);
         }
 
         /// <inheritdoc />
-        public IReadOnlyList<HostnamePortBinding> Query(HostnamePortKey key)
+        public HostnamePortBinding Find(HostnamePortKey key)
         {
             ThrowHelper.ThrowIfNull(key, nameof(key));
             ISslBindingFamilyOperations operations = GetSupportedBindingOperations(key);
-            return operations.QueryExact(key).Cast<HostnamePortBinding>().ToArray();
+            return (HostnamePortBinding)operations.FindExact(key);
         }
 
         /// <inheritdoc />
-        public IReadOnlyList<CcsPortBinding> Query(CcsPortKey key)
+        public CcsPortBinding Find(CcsPortKey key)
         {
             ThrowHelper.ThrowIfNull(key, nameof(key));
             ISslBindingFamilyOperations operations = GetSupportedBindingOperations(key);
-            return operations.QueryExact(key).Cast<CcsPortBinding>().ToArray();
+            return (CcsPortBinding)operations.FindExact(key);
         }
 
         /// <inheritdoc />
-        public IReadOnlyList<ScopedCcsBinding> Query(ScopedCcsKey key)
+        public ScopedCcsBinding Find(ScopedCcsKey key)
         {
             ThrowHelper.ThrowIfNull(key, nameof(key));
             ISslBindingFamilyOperations operations = GetSupportedBindingOperations(key);
-            return operations.QueryExact(key).Cast<ScopedCcsBinding>().ToArray();
+            return (ScopedCcsBinding)operations.FindExact(key);
         }
 
         /// <inheritdoc />
-        public IReadOnlyList<ISslBinding> Query(SslBindingKey key)
+        public ISslBinding Find(SslBindingKey key)
         {
             ThrowHelper.ThrowIfNull(key, nameof(key));
             ISslBindingFamilyOperations operations = GetSupportedBindingOperations(key);
-            return operations.QueryExact(key);
+            return operations.FindExact(key);
         }
 
         /// <inheritdoc />

--- a/src/SslCertBinding.Net/SslCertificateReference.cs
+++ b/src/SslCertBinding.Net/SslCertificateReference.cs
@@ -8,6 +8,20 @@ namespace SslCertBinding.Net
     /// </summary>
     public sealed class SslCertificateReference
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SslCertificateReference"/> class
+        /// using the default <c>MY</c> certificate store.
+        /// </summary>
+        /// <param name="thumbprint">The certificate thumbprint.</param>
+        /// <remarks>
+        /// Use this overload when you want the default Windows <c>MY</c> store.
+        /// Passing <c>null</c> to the string overload is not supported.
+        /// </remarks>
+        public SslCertificateReference(string thumbprint)
+            : this(thumbprint, "MY")
+        {
+        }
+
         /// <inheritdoc cref="SslCertificateReference.SslCertificateReference(string, string)" />
         public SslCertificateReference(string thumbprint, StoreName storeName)
             : this(thumbprint, storeName.ToString())
@@ -18,8 +32,8 @@ namespace SslCertBinding.Net
         /// Initializes a new instance of the <see cref="SslCertificateReference"/> class.
         /// </summary>
         /// <param name="thumbprint">The certificate thumbprint.</param>
-        /// <param name="storeName">The certificate store name.</param>
-        /// <exception cref="ArgumentException">Thrown when <paramref name="thumbprint"/> is null or empty.</exception>
+        /// <param name="storeName">The certificate store name. Must not be <c>null</c> or empty.</param>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="thumbprint"/> or <paramref name="storeName"/> is null or empty.</exception>
         public SslCertificateReference(string thumbprint, string storeName)
         {
             if (string.IsNullOrEmpty(thumbprint))
@@ -27,8 +41,13 @@ namespace SslCertBinding.Net
                 throw new ArgumentException("Value cannot be null or empty.", nameof(thumbprint));
             }
 
+            if (string.IsNullOrEmpty(storeName))
+            {
+                throw new ArgumentException("Value cannot be null or empty.", nameof(storeName));
+            }
+
             Thumbprint = thumbprint;
-            StoreName = storeName ?? "MY";
+            StoreName = storeName;
         }
 
         /// <inheritdoc cref="SslCertificateReference.From(System.Security.Cryptography.X509Certificates.X509Certificate2, string)" />
@@ -42,7 +61,7 @@ namespace SslCertBinding.Net
         /// and an explicit Windows certificate store.
         /// </summary>
         /// <param name="certificate">The certificate whose thumbprint should be referenced.</param>
-        /// <param name="storeName">The certificate store name.</param>
+        /// <param name="storeName">The certificate store name. Must not be <c>null</c> or empty.</param>
         /// <returns>The certificate reference.</returns>
         /// <exception cref="ArgumentNullException">Thrown when <paramref name="certificate"/> is <c>null</c>.</exception>
         public static SslCertificateReference From(X509Certificate2 certificate, string storeName) =>


### PR DESCRIPTION
- Replace exact `Query` overloads with `Find`
- Enable nullable reference types across library