### PR TITLE
#80 Add support for disabling legacy TLS protocols

### DIFF
--- a/src/SslCertBinding.Net.Tests/Compatibility/CertificateBindingCompatibilityTests.cs
+++ b/src/SslCertBinding.Net.Tests/Compatibility/CertificateBindingCompatibilityTests.cs
@@ -1,4 +1,4 @@
-#pragma warning disable CA1416
+﻿#pragma warning disable CA1416
 #pragma warning disable CS0618
 using System;
 using System.Collections.Generic;
@@ -23,7 +23,7 @@ namespace SslCertBinding.Net.Tests
                 new IpPortKey(IPAddress.Parse("127.0.0.1"), 443),
                 new SslCertificateReference("ABCDEF", StoreName.My),
                 Guid.NewGuid(),
-                new BindingOptions { DisableTls12 = true });
+                new BindingOptions { DisableTls12 = true, DisableLegacyTls = true });
             var configuration = new CertificateBindingConfiguration(new StubConfiguration
             {
                 QueryAllIpBindingsResult = new[] { ipBinding },
@@ -38,6 +38,7 @@ namespace SslCertBinding.Net.Tests
                 Assert.That(result[0].Thumbprint, Is.EqualTo(ipBinding.Certificate.Thumbprint));
                 Assert.That(result[0].StoreName, Is.EqualTo(ipBinding.Certificate.StoreName));
                 Assert.That(result[0].Options.DisableTls12, Is.True);
+                Assert.That(result[0].Options.DisableLegacyTls, Is.True);
             });
         }
 
@@ -270,6 +271,7 @@ namespace SslCertBinding.Net.Tests
         {
             var options = new BindingOptions
             {
+                DisableLegacyTls = true,
                 DisableTls12 = true,
                 EnableRevocationFreshnessTime = true,
                 NegotiateCertificate = true,
@@ -289,6 +291,7 @@ namespace SslCertBinding.Net.Tests
                 Assert.That(result.Certificate.Thumbprint, Is.EqualTo(binding.Thumbprint));
                 Assert.That(result.Certificate.StoreName, Is.EqualTo(binding.StoreName));
                 Assert.That(result.Options, Is.Not.SameAs(binding.Options));
+                Assert.That(result.Options.DisableLegacyTls, Is.True);
                 Assert.That(result.Options.DisableTls12, Is.True);
                 Assert.That(result.Options.EnableRevocationFreshnessTime, Is.True);
                 Assert.That(result.Options.NegotiateCertificate, Is.True);
@@ -309,6 +312,7 @@ namespace SslCertBinding.Net.Tests
             {
                 Assert.That(clone, Is.Not.Null);
                 Assert.That(clone.DisableTls12, Is.False);
+                Assert.That(clone.DisableLegacyTls, Is.False);
                 Assert.That(clone.NegotiateCertificate, Is.False);
                 Assert.That(clone.SslCtlIdentifier, Is.Null);
             });

--- a/src/SslCertBinding.Net.Tests/Configuration/SslBindingConfigurationIntegrationTestBase.cs
+++ b/src/SslCertBinding.Net.Tests/Configuration/SslBindingConfigurationIntegrationTestBase.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -234,6 +234,7 @@ namespace SslCertBinding.Net.Tests
                 VerifyRevocationWithCachedCertificateOnly = true,
                 EnableRevocationFreshnessTime = true,
                 NoUsageCheck = true,
+                DisableLegacyTls = true,
                 DisableTls12 = true,
             };
         }
@@ -251,6 +252,7 @@ namespace SslCertBinding.Net.Tests
                 VerifyRevocationWithCachedCertificateOnly = true,
                 EnableRevocationFreshnessTime = true,
                 NoUsageCheck = false,
+                DisableLegacyTls = false,
                 DisableTls12 = true,
             };
         }
@@ -280,6 +282,7 @@ namespace SslCertBinding.Net.Tests
                 Assert.That(actual.NegotiateCertificate, Is.EqualTo(expected.NegotiateCertificate));
                 Assert.That(actual.UseDsMappers, Is.EqualTo(expected.UseDsMappers));
                 Assert.That(actual.DoNotPassRequestsToRawFilters, Is.EqualTo(expected.DoNotPassRequestsToRawFilters));
+                Assert.That(actual.DisableLegacyTls, Is.EqualTo(expected.DisableLegacyTls));
                 Assert.That(actual.DisableTls12, Is.EqualTo(expected.DisableTls12));
             });
         }

--- a/src/SslCertBinding.Net.Tests/Configuration/SslBindingConfigurationUpsertTests.cs
+++ b/src/SslCertBinding.Net.Tests/Configuration/SslBindingConfigurationUpsertTests.cs
@@ -72,6 +72,7 @@ namespace SslCertBinding.Net.Tests
                     RevocationUrlRetrievalTimeout = TimeSpan.FromSeconds(5),
                     UseDsMappers = true,
                     VerifyRevocationWithCachedCertificateOnly = true,
+                    DisableLegacyTls = true,
                     DisableTls12 = true,
                 }));
 
@@ -91,6 +92,7 @@ namespace SslCertBinding.Net.Tests
                 AssertOutput(result.Output, @"URL Retrieval Timeout : 5000");
                 AssertOutput(result.Output, @"DS Mapper Usage : Enabled");
                 AssertOutput(result.Output, @"Negotiate Client Certificate : Enabled");
+                AssertOutput(result.Output, @"Disable Legacy TLS Versions  : Set");
                 AssertOutput(result.Output, @"Disable TLS1.2 : Set");
             });
         }
@@ -121,6 +123,7 @@ namespace SslCertBinding.Net.Tests
             {
                 UseDsMappers = true,
                 DisableTls12 = true,
+                DisableLegacyTls = true,
             }));
 
             ScopedCcsBinding binding = configuration.Find(key);
@@ -128,6 +131,7 @@ namespace SslCertBinding.Net.Tests
             {
                 UseDsMappers = true,
                 DisableTls12 = true,
+                DisableLegacyTls = true,
             }, null);
         }
 

--- a/src/SslCertBinding.Net/BindingOptions.cs
+++ b/src/SslCertBinding.Net/BindingOptions.cs
@@ -66,8 +66,8 @@ namespace SslCertBinding.Net
         /// </summary>
         public bool NoUsageCheck { get; set; }
 
-        /// <summary>
-        /// Disables legacy TLS versions (1.0 and 1.1) for the SSL binding.
+        /// <summary
+        /// Disables legacy TLS versions (1.0 and 1.1) of the TLS protocol.
         /// </summary>
         public bool DisableLegacyTls { get; set; }
 

--- a/src/SslCertBinding.Net/BindingOptions.cs
+++ b/src/SslCertBinding.Net/BindingOptions.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace SslCertBinding.Net
 {
@@ -65,6 +65,11 @@ namespace SslCertBinding.Net
         /// Indicates that no usage check is to be performed.
         /// </summary>
         public bool NoUsageCheck { get; set; }
+
+        /// <summary>
+        /// Disables legacy TLS versions (1.0 and 1.1) for the SSL binding.
+        /// </summary>
+        public bool DisableLegacyTls { get; set; }
 
         /// <summary>
         /// Disables version 1.2 of the TLS protocol.

--- a/src/SslCertBinding.Net/Compatibility/CertificateBinding.cs
+++ b/src/SslCertBinding.Net/Compatibility/CertificateBinding.cs
@@ -1,4 +1,4 @@
-#pragma warning disable CS0618
+﻿#pragma warning disable CS0618
 using System;
 using System.ComponentModel;
 using System.Net;
@@ -109,6 +109,7 @@ namespace SslCertBinding.Net
                 VerifyRevocationWithCachedCertificateOnly = options.VerifyRevocationWithCachedCertificateOnly,
                 EnableRevocationFreshnessTime = options.EnableRevocationFreshnessTime,
                 NoUsageCheck = options.NoUsageCheck,
+                DisableLegacyTls = options.DisableLegacyTls,
                 DisableTls12 = options.DisableTls12,
             };
     }

--- a/src/SslCertBinding.Net/Internal/Configuration/BindingFamilyInterop.cs
+++ b/src/SslCertBinding.Net/Internal/Configuration/BindingFamilyInterop.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
@@ -269,6 +269,7 @@ namespace SslCertBinding.Net.Internal
                     || options.NegotiateCertificate
                     || options.UseDsMappers
                     || options.DoNotPassRequestsToRawFilters
+                    || options.DisableLegacyTls
                     || options.DisableTls12))
             {
                 throw new NotSupportedException("Only default BindingOptions are supported for plain CCS bindings.");

--- a/src/SslCertBinding.Net/Internal/Interop/BindingStructures.cs
+++ b/src/SslCertBinding.Net/Internal/Interop/BindingStructures.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Globalization;
 using System.Net;
 using System.Runtime.InteropServices;
@@ -268,7 +268,8 @@ namespace SslCertBinding.Net.Internal.Interop
                     (options.NegotiateCertificate ? HttpApi.HTTP_SERVICE_CONFIG_SSL_FLAG.NEGOTIATE_CLIENT_CERT : 0)
                     | (options.UseDsMappers ? HttpApi.HTTP_SERVICE_CONFIG_SSL_FLAG.USE_DS_MAPPER : 0)
                     | (options.DoNotPassRequestsToRawFilters ? HttpApi.HTTP_SERVICE_CONFIG_SSL_FLAG.NO_RAW_FILTER : 0)
-                    | (options.DisableTls12 ? HttpApi.HTTP_SERVICE_CONFIG_SSL_FLAG.DISABLE_TLS_1_2 : 0),
+                    | (options.DisableTls12 ? HttpApi.HTTP_SERVICE_CONFIG_SSL_FLAG.DISABLE_TLS_1_2 : 0)
+                    | (options.DisableLegacyTls ? HttpApi.HTTP_SERVICE_CONFIG_SSL_FLAG.DISABLE_LEGACY_TLS : 0),
                 DefaultRevocationFreshnessTime = (int)options.RevocationFreshnessTime.TotalSeconds,
                 DefaultRevocationUrlRetrievalTimeout = (int)options.RevocationUrlRetrievalTimeout.TotalMilliseconds,
                 pSslCertStoreName = certificate.StoreName,
@@ -295,7 +296,8 @@ namespace SslCertBinding.Net.Internal.Interop
                     (options.NegotiateCertificate ? HttpApi.HTTP_SERVICE_CONFIG_SSL_FLAG.NEGOTIATE_CLIENT_CERT : 0)
                     | (options.UseDsMappers ? HttpApi.HTTP_SERVICE_CONFIG_SSL_FLAG.USE_DS_MAPPER : 0)
                     | (options.DoNotPassRequestsToRawFilters ? HttpApi.HTTP_SERVICE_CONFIG_SSL_FLAG.NO_RAW_FILTER : 0)
-                    | (options.DisableTls12 ? HttpApi.HTTP_SERVICE_CONFIG_SSL_FLAG.DISABLE_TLS_1_2 : 0),
+                    | (options.DisableTls12 ? HttpApi.HTTP_SERVICE_CONFIG_SSL_FLAG.DISABLE_TLS_1_2 : 0)
+                    | (options.DisableLegacyTls ? HttpApi.HTTP_SERVICE_CONFIG_SSL_FLAG.DISABLE_LEGACY_TLS : 0),
                 DefaultRevocationFreshnessTime = (int)options.RevocationFreshnessTime.TotalSeconds,
                 DefaultRevocationUrlRetrievalTimeout = (int)options.RevocationUrlRetrievalTimeout.TotalMilliseconds,
                 pDefaultSslCtlIdentifier = options.SslCtlIdentifier,
@@ -317,6 +319,7 @@ namespace SslCertBinding.Net.Internal.Interop
             UseDsMappers = HasFlag(paramDesc.DefaultFlags, HttpApi.HTTP_SERVICE_CONFIG_SSL_FLAG.USE_DS_MAPPER),
             DoNotPassRequestsToRawFilters = HasFlag(paramDesc.DefaultFlags, HttpApi.HTTP_SERVICE_CONFIG_SSL_FLAG.NO_RAW_FILTER),
             DisableTls12 = HasFlag(paramDesc.DefaultFlags, HttpApi.HTTP_SERVICE_CONFIG_SSL_FLAG.DISABLE_TLS_1_2),
+            DisableLegacyTls = HasFlag(paramDesc.DefaultFlags, HttpApi.HTTP_SERVICE_CONFIG_SSL_FLAG.DISABLE_LEGACY_TLS),
         };
 
         private static byte[] GetHashBytes(string thumbprint)

--- a/src/SslCertBinding.Net/Internal/Interop/HttpApi.cs
+++ b/src/SslCertBinding.Net/Internal/Interop/HttpApi.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
 using SslCertBinding.Net.Internal;
@@ -242,6 +242,7 @@ namespace SslCertBinding.Net.Internal.Interop
             USE_DS_MAPPER = 0x00000001,
             NEGOTIATE_CLIENT_CERT = 0x00000002,
             NO_RAW_FILTER = 0x00000004,
+            DISABLE_LEGACY_TLS = 0x00000400,
             DISABLE_TLS_1_2 = 0x00001000,
         }
 


### PR DESCRIPTION
  * Added a new property to the BindingOptions class allowing for disabling legacy TLS
  * Added the appropriate value corresponding to the legacy TLS disablement to the HTTP_SERVICE_CONFIG_SSL_FLAG enumeration
  * Adjusted the Bind method within the CreateConfigSslParam to set the DefaultFlags attribute according to the newly introduced property from the BindingOptions class.
  * Adjusted unit tests